### PR TITLE
Fix #3: use valid syntax in Tests/shell_test.jz

### DIFF
--- a/Tests/shell_test.jz
+++ b/Tests/shell_test.jz
@@ -1,12 +1,12 @@
 // Test script for Jitzu.Shell
 let x = 42
-print("x = " + x)
+print(`x = {x}`)
 
 let y = x + 1
-print("y = x + 1 = " + y)
+print(`y = x + 1 = {y}`)
 
-fun double(n) {
+fun double(n: Int): Int {
     n * 2
 }
 
-print("double(x) = " + double(x))
+print(`double(x) = {double(x)}`)


### PR DESCRIPTION
## Summary
- `Tests/shell_test.jz` crashed immediately with `S002: Syntax Error - Expected : but got Operator )` because `fun double(n)` omits the type annotation, and `"x = " + x` hits the still-open string-`+` issue.
- Updated the script to use typed params (`fun double(n: Int): Int`) and backtick interpolation (`` `x = {x}` ``) — both are current, supported syntax.
- Underlying parser/runtime bugs tracked in #4 and #7; this PR only unbreaks the sanity-check script.

## Test plan
- [x] `cd Jitzu.Shell && dotnet run -- ../Tests/shell_test.jz` — prints `x = 42`, `y = x + 1 = 43`, `double(x) = 84`.

Closes #3