### PR TITLE
Fix #4: support string concatenation with `+`

### DIFF
--- a/Jitzu.Core/Runtime/BinaryExpressionEvaluator.cs
+++ b/Jitzu.Core/Runtime/BinaryExpressionEvaluator.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using Jitzu.Core.Logging;
 
@@ -14,7 +15,7 @@ public static class BinaryExpressionEvaluator
         (ValueKind.Double, ValueKind.Double) => Value.FromBool(Math.Abs(a.F64 - b.F64) < 0),
         _ => Throw("lt", a, b)
     };
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Value Add(Value a, Value b) => (a.Kind, b.Kind) switch
     {
@@ -22,8 +23,46 @@ public static class BinaryExpressionEvaluator
         (ValueKind.Int, ValueKind.Double) => Value.FromDouble(a.I32 + b.F64),
         (ValueKind.Double, ValueKind.Int) => Value.FromDouble(a.F64 + b.I32),
         (ValueKind.Double, ValueKind.Double) => Value.FromDouble(a.F64 + b.F64),
+        (ValueKind.Ref, _) or (_, ValueKind.Ref) => ConcatIfString(a, b),
         _ => Throw("add", a, b)
     };
+
+    // String concatenation for `+`. Auto-stringifies primitives on the other
+    // side (int/double/bool) so `"x = " + 42` works. Non-string Ref values
+    // still throw — we don't want silent ToString() on arbitrary objects.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Value ConcatIfString(Value a, Value b)
+    {
+        if (a.Kind == ValueKind.Ref && a.Ref is string sa && TryStringify(b, out var tb))
+            return Value.FromRef(string.Concat(sa, tb));
+
+        if (b.Kind == ValueKind.Ref && b.Ref is string sb && TryStringify(a, out var ta))
+            return Value.FromRef(string.Concat(ta, sb));
+
+        return Throw("add", a, b);
+    }
+
+    private static bool TryStringify(Value v, out string result)
+    {
+        switch (v.Kind)
+        {
+            case ValueKind.Int:
+                result = v.I32.ToString(CultureInfo.InvariantCulture);
+                return true;
+            case ValueKind.Double:
+                result = v.F64.ToString(CultureInfo.InvariantCulture);
+                return true;
+            case ValueKind.Bool:
+                result = v.B.ToString();
+                return true;
+            case ValueKind.Ref when v.Ref is string s:
+                result = s;
+                return true;
+            default:
+                result = string.Empty;
+                return false;
+        }
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Value Sub(Value a, Value b) => (a.Kind, b.Kind) switch

--- a/Jitzu.Tests/StringConcatTests.cs
+++ b/Jitzu.Tests/StringConcatTests.cs
@@ -1,0 +1,128 @@
+using Jitzu.Core.Runtime;
+using Shouldly;
+
+namespace Jitzu.Tests;
+
+public class StringConcatTests
+{
+    [Test]
+    public async Task PlusOperator_StringPlusString_ConcatenatesAtRuntime()
+    {
+        const string source = """
+                              print("hello " + "world")
+                              """;
+
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("hello world");
+    }
+
+    [Test]
+    public async Task PlusOperator_StringPlusInt_StringifiesAndConcatenates()
+    {
+        const string source = """
+                              let x = 42
+                              print("x = " + x)
+                              """;
+
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("x = 42");
+    }
+
+    [Test]
+    public async Task PlusOperator_IntPlusString_StringifiesAndConcatenates()
+    {
+        const string source = """
+                              let x = 42
+                              print(x + " = answer")
+                              """;
+
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("42 = answer");
+    }
+
+    [Test]
+    public async Task PlusOperator_StringPlusBool_StringifiesAndConcatenates()
+    {
+        const string source = """
+                              print("flag = " + true)
+                              """;
+
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("flag = True");
+    }
+
+    [Test]
+    public void Add_StringPlusString_ReturnsConcatenatedRef()
+    {
+        var result = BinaryExpressionEvaluator.Add(
+            Value.FromRef("foo"),
+            Value.FromRef("bar"));
+
+        result.Kind.ShouldBe(ValueKind.Ref);
+        result.Ref.ShouldBe("foobar");
+    }
+
+    [Test]
+    public void Add_StringPlusInt_StringifiesRhs()
+    {
+        var result = BinaryExpressionEvaluator.Add(
+            Value.FromRef("x = "),
+            Value.FromInt(42));
+
+        result.Kind.ShouldBe(ValueKind.Ref);
+        result.Ref.ShouldBe("x = 42");
+    }
+
+    [Test]
+    public void Add_IntPlusString_StringifiesLhs()
+    {
+        var result = BinaryExpressionEvaluator.Add(
+            Value.FromInt(42),
+            Value.FromRef(" = x"));
+
+        result.Kind.ShouldBe(ValueKind.Ref);
+        result.Ref.ShouldBe("42 = x");
+    }
+
+    [Test]
+    public void Add_StringPlusDouble_UsesInvariantCulture()
+    {
+        var result = BinaryExpressionEvaluator.Add(
+            Value.FromRef("pi = "),
+            Value.FromDouble(3.14));
+
+        result.Kind.ShouldBe(ValueKind.Ref);
+        result.Ref.ShouldBe("pi = 3.14");
+    }
+
+    [Test]
+    public void Add_StringPlusBool_StringifiesBool()
+    {
+        var result = BinaryExpressionEvaluator.Add(
+            Value.FromRef("ok = "),
+            Value.FromBool(true));
+
+        result.Kind.ShouldBe(ValueKind.Ref);
+        result.Ref.ShouldBe("ok = True");
+    }
+
+    [Test]
+    public void Add_RefNonStringPlusRefNonString_StillThrows()
+    {
+        var lhs = Value.FromRef(new object());
+        var rhs = Value.FromRef(new object());
+
+        Should.Throw<OperationNotSupportedException>(() =>
+            BinaryExpressionEvaluator.Add(lhs, rhs));
+    }
+
+    [Test]
+    public void Add_StringPlusRefNonString_StillThrows()
+    {
+        var lhs = Value.FromRef("prefix:");
+        var rhs = Value.FromRef(new object());
+
+        Should.Throw<OperationNotSupportedException>(() =>
+            BinaryExpressionEvaluator.Add(lhs, rhs));
+    }
+}


### PR DESCRIPTION
## Summary
- `BinaryExpressionEvaluator.Add` now handles `string + *` / `* + string` via auto-stringification.
- Primitives (Int/Double/Bool) stringify with `InvariantCulture` so script output is locale-stable.
- Non-string `Ref` values still throw — deliberate: silently `ToString()`-ing arbitrary objects would hide bugs.
- Semantic analyser leaves binary expression return type as `object`, so no typing changes needed.

## Test plan
- [x] 11 new tests in `StringConcatTests.cs` cover: string+string, string+int, int+string, string+bool, string+double (invariant culture), unit-level checks on `BinaryExpressionEvaluator.Add`, plus regression guards that non-string `Ref` operands still throw.
- [x] Full suite: 260/260 passing (`dotnet test`).

Closes #4