### PR TITLE
Fix #5: detect `${expr}` in backtick strings and emit helpful error

### DIFF
--- a/Jitzu.Core/Lexer.cs
+++ b/Jitzu.Core/Lexer.cs
@@ -424,6 +424,36 @@ public ref struct Lexer(ReadOnlySpan<char> filePath, ReadOnlySpan<char> input, i
                     return tokens;
                 }
 
+                case '$' when Peek(1) is '{':
+                {
+                    var start = _currentLocation;
+                    var dollarIndex = _index;
+
+                    // Scan the inner expression to echo it back in the error (best-effort).
+                    var scan = _index + 2;
+                    var depth = 0;
+                    while (scan <= _maxIndex)
+                    {
+                        var ch = _input[scan];
+                        if (ch == '{') depth++;
+                        else if (ch == '}')
+                        {
+                            if (depth == 0) break;
+                            depth--;
+                        }
+                        scan++;
+                    }
+                    var inner = scan <= _maxIndex
+                        ? _input[(_index + 2)..scan].ToString()
+                        : "expr";
+
+                    _currentLocation.AdvanceBy(1);
+                    _index++;
+                    throw new JitzuException(
+                        new SourceSpan(_filePath, _index - dollarIndex, start, _currentLocation),
+                        $"Did you mean `{{{inner}}}` instead of `${{{inner}}}`? Jitzu uses `{{expr}}` for string interpolation; drop the `$`.");
+                }
+
                 case '{':
                 {
                     // gather the text up to to now

--- a/Jitzu.Tests/LexerTests/InterpolationTests.cs
+++ b/Jitzu.Tests/LexerTests/InterpolationTests.cs
@@ -1,0 +1,42 @@
+using Jitzu.Core;
+using Shouldly;
+
+namespace Jitzu.Tests.LexerTests;
+
+public class InterpolationTests
+{
+    [Test]
+    public void DollarBrace_InBacktickString_ThrowsWithHelpfulMessage()
+    {
+        JitzuException? caught = null;
+        try
+        {
+            var lexer = new Lexer("", "`Hello, ${name}`");
+            lexer.Lex();
+        }
+        catch (JitzuException ex)
+        {
+            caught = ex;
+        }
+
+        caught.ShouldNotBeNull();
+        caught.Message.ShouldContain("{name}");
+        caught.Message.ShouldContain("{expr}");
+    }
+
+    [Test]
+    public void PlainBrace_InBacktickString_DoesNotThrow()
+    {
+        var lexer = new Lexer("", "`Hello, {name}`");
+        var tokens = lexer.Lex();
+        tokens.ShouldNotBeEmpty();
+    }
+
+    [Test]
+    public void LiteralDollar_NotFollowedByBrace_DoesNotThrow()
+    {
+        var lexer = new Lexer("", "`Price: $5`");
+        var tokens = lexer.Lex();
+        tokens.ShouldNotBeEmpty();
+    }
+}


### PR DESCRIPTION
Closes #5

## Summary

- `${name}` inside backtick strings silently produced wrong output (`Hello, $Tony` instead of `Hello, Tony`) because the lexer consumed `$` as literal text then interpolated `{name}` normally.
- The lexer now detects `$` immediately followed by `{` inside a backtick string and throws a `JitzuException` suggesting the correct form and echoing the user's expression: `Did you mean \`{name}\` instead of \`${name}\`? Jitzu uses \`{expr}\` for string interpolation; drop the \`$\`.`

## Test plan

- [x] New `Jitzu.Tests/LexerTests/InterpolationTests.cs`:
  - `DollarBrace_InBacktickString_ThrowsWithHelpfulMessage`
  - `PlainBrace_InBacktickString_DoesNotThrow`
  - `LiteralDollar_NotFollowedByBrace_DoesNotThrow`
- [x] Full suite: 263/263 passing
- [x] Manual repro from issue now errors with a helpful message