### PR TITLE
Add regression test for #11 (generic type annotations)

### DIFF
--- a/Jitzu.Tests/GenericReturnTypeTests.cs
+++ b/Jitzu.Tests/GenericReturnTypeTests.cs
@@ -1,0 +1,34 @@
+using Jitzu.Core;
+using Jitzu.Core.Language;
+using Shouldly;
+
+namespace Jitzu.Tests;
+
+public class GenericReturnTypeTests
+{
+    [Test]
+    public void Parse_FunctionWithGenericReturnType_DoesNotThrow()
+    {
+        const string source = """
+                              fun divide(a: Double, b: Double): Result<Double, String> {
+                                  return Ok(a)
+                              }
+                              """;
+
+        Should.NotThrow(() => Parser.Parse("", source));
+    }
+
+    [Test]
+    public async Task FullPipeline_FunctionWithGenericReturnType_Compiles()
+    {
+        const string source = """
+                              fun id(a: Int): Result<Int, String> {
+                                  return Ok(a)
+                              }
+                              print("ok")
+                              """;
+
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("ok");
+    }
+}


### PR DESCRIPTION
Closes #11.

The bug reported against v0.1.23 was already fixed on main by 26db4a5 ("Parse and resolve generic type annotations"). This PR locks the fix in with a test that exercises `fun id(a: Int): Result<Int, String>` through both the parser and the full compilation pipeline.

## Test plan
- [x] `dotnet test --treenode-filter "/*/*/GenericReturnTypeTests/**"` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)