### PR TITLE
Fix #14: forward script args past the jz host parser

### DIFF
--- a/Jitzu.Shell/Models/JitzuOptions.cs
+++ b/Jitzu.Shell/Models/JitzuOptions.cs
@@ -50,5 +50,47 @@ public partial class JitzuOptions
     public string? ScriptPath { get; init; }
 
     [Arg(Help = "Additional arguments to pass to the script")]
-    public string[] ScriptArgs { get; init; } = [];
+    public string[] ScriptArgs { get; set; } = [];
+
+    /// <summary>
+    /// Splits argv into (hostArgs, scriptArgs) so flags after the script path are
+    /// forwarded verbatim to the script instead of being eaten by the jz host parser.
+    ///
+    /// Rules:
+    /// - An explicit `--` separator splits at that token.
+    /// - Otherwise the first arg that looks like a script path (ends in .jz, or is the
+    ///   literal "upgrade", or is a file that exists) is the boundary; everything after
+    ///   it (exclusive) becomes script args.
+    /// </summary>
+    public static (string[] HostArgs, string[] ScriptArgs) SplitArgs(string[] args)
+    {
+        var dashDashIndex = Array.IndexOf(args, "--");
+        if (dashDashIndex >= 0)
+        {
+            var host = args[..dashDashIndex];
+            var script = args[(dashDashIndex + 1)..];
+            return (host, script);
+        }
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var a = args[i];
+            if (a.Length == 0 || a[0] == '-')
+                continue;
+
+            var looksLikeScript = a.EndsWith(".jz", StringComparison.OrdinalIgnoreCase)
+                || a == "upgrade"
+                || File.Exists(a)
+                || File.Exists(Path.ChangeExtension(a, "jz"));
+
+            if (!looksLikeScript)
+                continue;
+
+            var host = args[..(i + 1)];
+            var script = args[(i + 1)..];
+            return (host, script);
+        }
+
+        return (args, []);
+    }
 }

--- a/Jitzu.Shell/Program.cs
+++ b/Jitzu.Shell/Program.cs
@@ -17,7 +17,10 @@ using System.Reflection;
 Console.OutputEncoding = Encoding.UTF8;
 EnableAnsiSupport();
 
-var options = JitzuOptions.Parse(args);
+var (hostArgs, scriptArgs) = JitzuOptions.SplitArgs(args);
+var options = JitzuOptions.Parse(hostArgs);
+if (scriptArgs.Length > 0)
+    options.ScriptArgs = scriptArgs;
 
 // Clean up leftover upgrade file from previous self-update (Windows)
 CleanupOldBinary();

--- a/Jitzu.Tests/ScriptArgsSplitTests.cs
+++ b/Jitzu.Tests/ScriptArgsSplitTests.cs
@@ -1,0 +1,47 @@
+using Jitzu.Shell.Models;
+using Shouldly;
+
+namespace Jitzu.Tests;
+
+public class ScriptArgsSplitTests
+{
+    [Test]
+    public void NoScript_AllArgsGoToHost()
+    {
+        var (host, script) = JitzuOptions.SplitArgs(["-d", "--telemetry"]);
+        host.ShouldBe(["-d", "--telemetry"]);
+        script.ShouldBeEmpty();
+    }
+
+    [Test]
+    public void ScriptPath_TrailingArgsGoToScript()
+    {
+        var (host, script) = JitzuOptions.SplitArgs(["-d", "script.jz", "--skip-clean", "foo"]);
+        host.ShouldBe(["-d", "script.jz"]);
+        script.ShouldBe(["--skip-clean", "foo"]);
+    }
+
+    [Test]
+    public void DashDashSeparator_SplitsThere()
+    {
+        var (host, script) = JitzuOptions.SplitArgs(["-d", "script.jz", "--", "--skip-clean"]);
+        host.ShouldBe(["-d", "script.jz"]);
+        script.ShouldBe(["--skip-clean"]);
+    }
+
+    [Test]
+    public void DashDashSeparator_BeforeScriptPath()
+    {
+        var (host, script) = JitzuOptions.SplitArgs(["--", "--anything", "goes"]);
+        host.ShouldBeEmpty();
+        script.ShouldBe(["--anything", "goes"]);
+    }
+
+    [Test]
+    public void ScriptArgsWithoutLeadingDashes_StillCaptured()
+    {
+        var (host, script) = JitzuOptions.SplitArgs(["script.jz", "arg1", "arg2"]);
+        host.ShouldBe(["script.jz"]);
+        script.ShouldBe(["arg1", "arg2"]);
+    }
+}


### PR DESCRIPTION
Closes #14.

## Summary
- `jz script.jz --skip-clean` now forwards `--skip-clean` to the script instead of having it eaten by the jz host's Clap.Net parser.
- `--` works as the conventional end-of-options separator (previously threw inside `Clap.Net.ArgsLexer`).

Implementation: pre-split argv before parsing. Everything after `--`, or after the first script-looking positional, is set verbatim on `JitzuOptions.ScriptArgs`.

## Test plan
- [x] Unit tests for `SplitArgs` cover: no script, trailing args, `--` separator, `--` before script, bare positional script args
- [x] Full test suite passes (268 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)