### PR TITLE
Fix #13: bool equality and if/else codegen

### DIFF
--- a/Jitzu.Core/Runtime/BinaryExpressionEvaluator.cs
+++ b/Jitzu.Core/Runtime/BinaryExpressionEvaluator.cs
@@ -10,10 +10,14 @@ public static class BinaryExpressionEvaluator
     public static Value Equal(Value a, Value b) => (a.Kind, b.Kind) switch
     {
         (ValueKind.Int, ValueKind.Int) => Value.FromBool(a.I32 == b.I32),
-        (ValueKind.Int, ValueKind.Double) => Value.FromBool(Math.Abs(a.I32 - b.F64) < 0),
-        (ValueKind.Double, ValueKind.Int) => Value.FromBool(Math.Abs(a.F64 - b.I32) < 0),
-        (ValueKind.Double, ValueKind.Double) => Value.FromBool(Math.Abs(a.F64 - b.F64) < 0),
-        _ => Throw("lt", a, b)
+        (ValueKind.Int, ValueKind.Double) => Value.FromBool(a.I32 == b.F64),
+        (ValueKind.Double, ValueKind.Int) => Value.FromBool(a.F64 == b.I32),
+        (ValueKind.Double, ValueKind.Double) => Value.FromBool(a.F64 == b.F64),
+        (ValueKind.Bool, ValueKind.Bool) => Value.FromBool(a.B == b.B),
+        (ValueKind.Null, ValueKind.Null) => Value.True,
+        (ValueKind.Null, _) or (_, ValueKind.Null) => Value.False,
+        (ValueKind.Ref, ValueKind.Ref) => Value.FromBool(Equals(a.Ref, b.Ref)),
+        _ => Value.False
     };
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Jitzu.Core/Runtime/Compilation/ByteCodeCompiler.cs
+++ b/Jitzu.Core/Runtime/Compilation/ByteCodeCompiler.cs
@@ -702,19 +702,24 @@ public sealed class ByteCodeCompiler(RuntimeProgram program)
     private void CompileIfExpression(IfExpression ifExpression)
     {
         EmitExpression(ifExpression.Condition);
-        int jumpOpAddress = _currentChunk.Code.Count;
+        int jumpIfFalseAddress = _currentChunk.Code.Count;
         _currentChunk.Emit(OpCode.JumpIfFalse, ifExpression.Condition.Location, 0);
 
         EmitExpression(ifExpression.Then);
 
         if (ifExpression.Else is null)
         {
-            PatchJump(jumpOpAddress, _currentChunk.Code.Count);
+            PatchJump(jumpIfFalseAddress, _currentChunk.Code.Count);
             return;
         }
 
-        PatchJump(jumpOpAddress, _currentChunk.Code.Count);
+        // Skip over the else branch when the then branch was taken.
+        int jumpOverElseAddress = _currentChunk.Code.Count;
+        _currentChunk.Emit(OpCode.Jump, ifExpression.Location, 0);
+
+        PatchJump(jumpIfFalseAddress, _currentChunk.Code.Count);
         EmitExpression(ifExpression.Else);
+        PatchJump(jumpOverElseAddress, _currentChunk.Code.Count);
     }
 
     private void EmitBlockBody(BlockBodyExpression body)

--- a/Jitzu.Core/Runtime/Value.cs
+++ b/Jitzu.Core/Runtime/Value.cs
@@ -34,8 +34,11 @@ public readonly record struct Value
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Value FromDouble(double v) => new(ValueKind.Double, d: v);
 
+    public static readonly Value True = new(ValueKind.Bool, b: true);
+    public static readonly Value False = new(ValueKind.Bool, b: false);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Value FromBool(bool v) => new(ValueKind.Bool, b: v);
+    public static Value FromBool(bool v) => v ? True : False;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Value FromRef(object? v) =>

--- a/Jitzu.Tests/BinaryEqualityTests.cs
+++ b/Jitzu.Tests/BinaryEqualityTests.cs
@@ -1,0 +1,58 @@
+using Jitzu.Core.Runtime;
+using Shouldly;
+
+namespace Jitzu.Tests;
+
+public class BinaryEqualityTests
+{
+    [Test]
+    public void Equal_BoolBool_True()
+    {
+        BinaryExpressionEvaluator.Equal(Value.FromBool(true), Value.FromBool(true)).B.ShouldBeTrue();
+        BinaryExpressionEvaluator.Equal(Value.FromBool(false), Value.FromBool(false)).B.ShouldBeTrue();
+    }
+
+    [Test]
+    public void Equal_BoolBool_False()
+    {
+        BinaryExpressionEvaluator.Equal(Value.FromBool(true), Value.FromBool(false)).B.ShouldBeFalse();
+    }
+
+    [Test]
+    public void Equal_IntDouble_NumericEquality()
+    {
+        BinaryExpressionEvaluator.Equal(Value.FromInt(2), Value.FromDouble(2.0)).B.ShouldBeTrue();
+        BinaryExpressionEvaluator.Equal(Value.FromDouble(2.0), Value.FromInt(2)).B.ShouldBeTrue();
+        BinaryExpressionEvaluator.Equal(Value.FromDouble(2.0), Value.FromDouble(2.0)).B.ShouldBeTrue();
+        BinaryExpressionEvaluator.Equal(Value.FromDouble(2.0), Value.FromDouble(3.0)).B.ShouldBeFalse();
+    }
+
+    [Test]
+    public void Equal_StringString_StructuralEquality()
+    {
+        BinaryExpressionEvaluator.Equal(Value.FromRef("a"), Value.FromRef("a")).B.ShouldBeTrue();
+        BinaryExpressionEvaluator.Equal(Value.FromRef("a"), Value.FromRef("b")).B.ShouldBeFalse();
+    }
+
+    [Test]
+    public async Task IfBoolEqTrue_TakesThenBranch()
+    {
+        const string source = """
+                              let r = true
+                              if r == true { print("yes") } else { print("no") }
+                              """;
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("yes");
+    }
+
+    [Test]
+    public async Task IfBoolEqFalse_TakesThenBranch()
+    {
+        const string source = """
+                              let r = false
+                              if r == false { print("yes") } else { print("no") }
+                              """;
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("yes");
+    }
+}


### PR DESCRIPTION
Closes #13.

## Summary
- `==` on Bool no longer throws "Operation lt not supported". The `Equal` evaluator now handles Bool/Bool, Null/Null, Ref/Ref, and falls back to `false` for cross-kind comparisons. Float equality is also fixed (the old `Math.Abs(a-b) < 0` check was always false).
- The mislabeled "lt" throw branch is gone.
- Adds `Value.True` / `Value.False` statics so common boolean results don't allocate a fresh `Value` per call.

## Latent if/else codegen fix
Fixing equality exposed a separate silent miscompile: `CompileIfExpression` never emitted an unconditional jump over the else branch, so for `if cond { A } else { B }` both `A` and `B` ran when `cond` was true. Fixed by emitting `OpCode.Jump` after the then body when an else exists.

## Test plan
- [x] `BinaryEqualityTests` cover Bool/Bool, Int/Double mixed, String/String, and full-pipeline `if r == true` / `if r == false`
- [x] Full test suite: 269 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)