### PR TITLE
Fix #12: support prefix '!' and unary '-'

### DIFF
--- a/Jitzu.Core/Language/Expressions.cs
+++ b/Jitzu.Core/Language/Expressions.cs
@@ -365,6 +365,13 @@ public record AssignmentExpression : Expression
     public Token Operator { get; init; }
 }
 
+public record UnaryExpression : Expression
+{
+    public required string Operator { get; init; }
+    public required Expression Operand { get; set; }
+    public override string ToString() => $"{Operator}{Operand}";
+}
+
 public record InplaceIncrementExpression : Expression
 {
     public required Expression Subject { get; set; }

--- a/Jitzu.Core/Parser.cs
+++ b/Jitzu.Core/Parser.cs
@@ -370,6 +370,18 @@ public ref struct Parser(ReadOnlySpan<Token> tokens)
 
     private Expression ParsePrimaryExpression()
     {
+        if (_current is { Type: TokenType.Operator, Value: "!" or "-" } prefixToken)
+        {
+            MoveNext();
+            var operand = ParsePrimaryExpression();
+            return new UnaryExpression
+            {
+                Operator = prefixToken.Value,
+                Operand = operand,
+                Location = prefixToken.Span.Extend(operand.Location),
+            };
+        }
+
         switch (_current)
         {
             case { Type: TokenType.Comment } token:

--- a/Jitzu.Core/Runtime/ByteCodeInterpreter.cs
+++ b/Jitzu.Core/Runtime/ByteCodeInterpreter.cs
@@ -267,6 +267,16 @@ public ref struct ByteCodeInterpreter
                         break;
                     }
 
+                    case OpCode.Not:
+                    {
+                        var v = _programStack.Pop();
+                        if (v.Kind != ValueKind.Bool)
+                            throw new InvalidOperationException(
+                                $"Operator '!' requires a Bool operand, got {v.Kind}.");
+                        _programStack.Push(Value.FromBool(!v.B));
+                        break;
+                    }
+
                     case OpCode.Compare:
                     {
                         EvaluateCompare();

--- a/Jitzu.Core/Runtime/Compilation/AstTransformer.cs
+++ b/Jitzu.Core/Runtime/Compilation/AstTransformer.cs
@@ -75,6 +75,7 @@ public class AstTransformer(RuntimeProgram program)
             BlockBodyExpression e => TransformBlockBody(e, slotMapBuilder),
             FunctionCallExpression e => TransformFunctionCallExpression(e, slotMapBuilder),
             BinaryExpression e => TransformBinaryExpression(e, slotMapBuilder),
+            UnaryExpression e => e with { Operand = TransformExpression(e.Operand, slotMapBuilder) },
             IfExpression e => TransformIfExpression(e, slotMapBuilder),
             IndexerExpression e => TransformIndexerExpression(e, slotMapBuilder),
             TryExpression e => TransformTryExpression(e, slotMapBuilder),
@@ -689,6 +690,10 @@ public class AstTransformer(RuntimeProgram program)
             {
                 Left = RewriteCapturedLocals(be.Left, capturedSlots),
                 Right = RewriteCapturedLocals(be.Right, capturedSlots),
+            },
+            UnaryExpression ue => ue with
+            {
+                Operand = RewriteCapturedLocals(ue.Operand, capturedSlots),
             },
             FunctionCallExpression fce => RewriteFunctionCall(fce, capturedSlots),
             ReturnExpression re => re with

--- a/Jitzu.Core/Runtime/Compilation/ByteCodeCompiler.cs
+++ b/Jitzu.Core/Runtime/Compilation/ByteCodeCompiler.cs
@@ -174,6 +174,28 @@ public sealed class ByteCodeCompiler(RuntimeProgram program)
                 break;
             }
 
+            case UnaryExpression unary:
+            {
+                switch (unary.Operator)
+                {
+                    case "!":
+                        EmitExpression(unary.Operand);
+                        _currentChunk.Emit(OpCode.Not, unary.Location);
+                        break;
+
+                    case "-":
+                        // Lower `-x` to `0 - x` to reuse the existing Sub op.
+                        EmitConstant(0, unary.Location);
+                        EmitExpression(unary.Operand);
+                        _currentChunk.Emit(OpCode.Sub, unary.Location);
+                        break;
+
+                    default:
+                        throw new NotSupportedException($"Unsupported unary operator: {unary.Operator}");
+                }
+                break;
+            }
+
             case BinaryExpression binOp:
             {
                 EmitExpression(binOp.Left);

--- a/Jitzu.Core/Runtime/Compilation/SemanticAnalyser.cs
+++ b/Jitzu.Core/Runtime/Compilation/SemanticAnalyser.cs
@@ -105,6 +105,12 @@ public class SemanticAnalyser(RuntimeProgram program)
                 return binOp;
             }
 
+            case UnaryExpression unary:
+            {
+                unary.Operand = AnalyseExpression(unary.Operand);
+                return unary;
+            }
+
             case IIdentifierLiteral identifierLiteral:
                 return AnalyseIdentifierLiteral(identifierLiteral);
 
@@ -565,6 +571,8 @@ public class SemanticAnalyser(RuntimeProgram program)
             DoubleLiteral => typeof(double),
             BooleanLiteral => typeof(bool),
             BinaryExpression e => ResolveBinaryExpressionReturnType(e),
+            UnaryExpression { Operator: "!" } => typeof(bool),
+            UnaryExpression { Operator: "-" } e => ResolveType(e.Operand),
             MatchExpression e => ResolveMatchExpressionReturnType(e),
             BlockBodyExpression e => ResolveBlockBodyReturnType(e),
             TryExpression e => e.ReturnType ?? ResolveType(e.Body),

--- a/Jitzu.Core/Runtime/OpCode.cs
+++ b/Jitzu.Core/Runtime/OpCode.cs
@@ -51,4 +51,5 @@ public enum OpCode : byte
     MakeClosure,
     IndexGetDirect,
     NewList,
+    Not,
 }

--- a/Jitzu.Tests/UnaryExpressionTests.cs
+++ b/Jitzu.Tests/UnaryExpressionTests.cs
@@ -1,0 +1,50 @@
+using Shouldly;
+
+namespace Jitzu.Tests;
+
+public class UnaryExpressionTests
+{
+    [Test]
+    public async Task Bang_NegatesTrue()
+    {
+        const string source = """
+                              let x = true
+                              print("" + !x)
+                              """;
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("False");
+    }
+
+    [Test]
+    public async Task Bang_NegatesFalse()
+    {
+        const string source = """
+                              let x = false
+                              print("" + !x)
+                              """;
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("True");
+    }
+
+    [Test]
+    public async Task Bang_DoubleNegation()
+    {
+        const string source = """
+                              let x = true
+                              print("" + !!x)
+                              """;
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("True");
+    }
+
+    [Test]
+    public async Task UnaryMinus_NegatesInt()
+    {
+        const string source = """
+                              let x = 5
+                              print(-x)
+                              """;
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("-5");
+    }
+}


### PR DESCRIPTION
Closes #12.

## Summary
- `!x` and `-x` now parse and compile. Previously `!` fell through to a bare `OperatorLiteral` in primary position and crashed the bytecode compiler with `Unhandled AST node: OperatorLiteral`.
- Adds a `UnaryExpression` AST node, prefix-operator branch in `ParsePrimaryExpression`, and matching cases in `SemanticAnalyser`, `AstTransformer` (including captured-locals rewrite), and `ByteCodeCompiler`.
- New `OpCode.Not` is dispatched in `ByteCodeInterpreter` and rejects non-Bool operands with a clear message.
- Unary `-` is lowered to `0 - x` to reuse the existing `Sub` op rather than introducing a redundant `Neg` opcode.

## Test plan
- [x] `UnaryExpressionTests` cover `!true`, `!false`, `!!true`, and `-x` for ints
- [x] Full test suite: 267 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)