### PR TITLE
Fix match-arm block bodies (and any block) with ';' between statements

### DIFF
--- a/Jitzu.Core/Parser.cs
+++ b/Jitzu.Core/Parser.cs
@@ -769,7 +769,11 @@ public ref struct Parser(ReadOnlySpan<Token> tokens)
 
         var body = ImmutableArray.CreateBuilder<Expression>();
         while (!IsNext('}'))
+        {
             body.Add(IsNext('{') ? ParseBlockBodyExpression() : ParseExpression());
+            if (_current is { Type: TokenType.Punctuation, Value: ";" })
+                MoveNext();
+        }
 
         var closeBracket = ExpectAndConsume('}');
 

--- a/Jitzu.Tests/BlockBodySemicolonTests.cs
+++ b/Jitzu.Tests/BlockBodySemicolonTests.cs
@@ -1,0 +1,35 @@
+using Shouldly;
+
+namespace Jitzu.Tests;
+
+public class BlockBodySemicolonTests
+{
+    [Test]
+    public async Task FunctionBody_StatementSemicolonExpression_ParsesAndRuns()
+    {
+        const string source = """
+                              fun go() {
+                                  print("a"); print("b")
+                              }
+                              go()
+                              """;
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("a\nb");
+    }
+
+    [Test]
+    public async Task MatchArm_BlockWithSemicolon_ParsesAndRuns()
+    {
+        const string source = """
+                              fun side() { print("ran side") }
+                              let x = 1
+                              let result = match x {
+                                  1 => { side(); "one" },
+                                  _ => "other",
+                              }
+                              print(result)
+                              """;
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("ran side\none");
+    }
+}


### PR DESCRIPTION
Refs #15.

## Summary
`ParseBlockBodyExpression` looped on `while (!IsNext('}'))` and called `ParseExpression` for each entry, but never consumed the `;` between statements. The top-level `Parse()` loop already does this — the block-body loop just hadn't been brought in line.

This blocks match arms with block bodies like `Err(_) => { die(\"...\"); \"\" }` (and any other `{ stmt; expr }` block) — the parser bails on the `;`.

Spotted while running a real-world `bootstrap.jz` script that hit this on line 55.

## Test plan
- [x] `BlockBodySemicolonTests` covers function bodies with `print("a"); print("b")` and a match arm with `{ side(); "one" }`
- [x] Full test suite: 265 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)