### PR TITLE
Add continue and break for for/while loops

### DIFF
--- a/Jitzu.Core/Language/Expressions.cs
+++ b/Jitzu.Core/Language/Expressions.cs
@@ -42,6 +42,9 @@ public record ReturnExpression : Expression
     public required Expression? ReturnValue { get; set; }
 }
 
+public record ContinueExpression : Expression;
+public record BreakExpression : Expression;
+
 public record TryExpression : Expression
 {
     public required KeywordLiteral TryKeyword { get; init; }

--- a/Jitzu.Core/Parser.cs
+++ b/Jitzu.Core/Parser.cs
@@ -493,6 +493,14 @@ public ref struct Parser(ReadOnlySpan<Token> tokens)
             case { Type: TokenType.Keyword, Value: "new" }:
                 return ParseNewKeywordExpression();
 
+            case { Type: TokenType.Keyword, Value: "continue" } continueToken:
+                MoveNext();
+                return new ContinueExpression { Location = continueToken.Span };
+
+            case { Type: TokenType.Keyword, Value: "break" } breakToken:
+                MoveNext();
+                return new BreakExpression { Location = breakToken.Span };
+
             case { Type: TokenType.Keyword } keyword:
                 throw new NotImplementedException($"Keyword {TokenFormatter.Format(keyword)} not implemented");
 

--- a/Jitzu.Core/Runtime/Compilation/ByteCodeCompiler.cs
+++ b/Jitzu.Core/Runtime/Compilation/ByteCodeCompiler.cs
@@ -14,6 +14,19 @@ public sealed class ByteCodeCompiler(RuntimeProgram program)
 {
     private Chunk _currentChunk = null!;
     private readonly Stack<ContextItem> _context = new();
+    private readonly Stack<LoopContext> _loops = new();
+
+    private sealed class LoopContext
+    {
+        // `continue` target — for while: loop top (re-evaluate condition); for `for`:
+        // the increment block (so the post-step runs). Marked when the target site is
+        // known, which may be after the body has emitted the continue jump, so we use
+        // a back-patched Label rather than a raw int.
+        public required Label ContinueLabel { get; init; }
+
+        // Forward `break` target — patched once the loop end is known.
+        public required Label BreakLabel { get; init; }
+    }
 
     public UserFunction Compile(Expression[] expressions)
     {
@@ -480,6 +493,22 @@ public sealed class ByteCodeCompiler(RuntimeProgram program)
                 CompileIfExpression(ifExpression);
                 break;
 
+            case ContinueExpression:
+            {
+                if (_loops.Count == 0)
+                    throw new InvalidOperationException("`continue` outside of a loop");
+                _currentChunk.EmitJump(OpCode.Loop, expr.Location, _loops.Peek().ContinueLabel);
+                break;
+            }
+
+            case BreakExpression:
+            {
+                if (_loops.Count == 0)
+                    throw new InvalidOperationException("`break` outside of a loop");
+                _currentChunk.EmitJump(OpCode.Jump, expr.Location, _loops.Peek().BreakLabel);
+                break;
+            }
+
             case ReturnExpression returnExpression:
                 if (returnExpression.ReturnValue is not null)
                 {
@@ -768,15 +797,23 @@ public sealed class ByteCodeCompiler(RuntimeProgram program)
         _currentChunk.Emit(getOp, forExpr.Location, counterSlot);
         _currentChunk.Emit(iterSetOp, forExpr.Location, iterSlot);
 
+        var breakLabel = Chunk.NewLabel();
+        var continueLabel = Chunk.NewLabel();
+        _loops.Push(new LoopContext { ContinueLabel = continueLabel, BreakLabel = breakLabel });
+
         // Body
         EmitBlockBody(forExpr.Body);
 
-        // Increment hidden counter
+        _loops.Pop();
+
+        // Increment hidden counter — this is the continue target
+        _currentChunk.MarkLabel(continueLabel);
         _currentChunk.Emit(getOp, forExpr.Location, counterSlot);
         _currentChunk.Emit(OpCode.Inc, forExpr.Location);
         _currentChunk.Emit(setOp, forExpr.Location, counterSlot);
 
         _currentChunk.Emit(OpCode.Loop, forExpr.Location, loopStart);
+        _currentChunk.MarkLabel(breakLabel);
         var endOfLoop = _currentChunk.Code.Count;
 
         PatchJump(jumpAddress, endOfLoop);
@@ -826,15 +863,23 @@ public sealed class ByteCodeCompiler(RuntimeProgram program)
         _currentChunk.Emit(OpCode.IndexGetDirect, forExpr.Location);
         _currentChunk.Emit(iterSetOp, forExpr.Location, iterSlot);
 
+        var breakLabel = Chunk.NewLabel();
+        var continueLabel = Chunk.NewLabel();
+        _loops.Push(new LoopContext { ContinueLabel = continueLabel, BreakLabel = breakLabel });
+
         // Body
         EmitBlockBody(forExpr.Body);
 
-        // Increment counter
+        _loops.Pop();
+
+        // Increment counter — `continue` target
+        _currentChunk.MarkLabel(continueLabel);
         _currentChunk.Emit(getOp, forExpr.Location, counterSlot);
         _currentChunk.Emit(OpCode.Inc, forExpr.Location);
         _currentChunk.Emit(setOp, forExpr.Location, counterSlot);
 
         _currentChunk.Emit(OpCode.Loop, forExpr.Location, loopStart);
+        _currentChunk.MarkLabel(breakLabel);
         var endOfLoop = _currentChunk.Code.Count;
 
         PatchJump(jumpAddress, endOfLoop);
@@ -842,15 +887,21 @@ public sealed class ByteCodeCompiler(RuntimeProgram program)
 
     private void CompileWhileExpression(WhileExpression whileExpr)
     {
+        var continueLabel = Chunk.NewLabel();
+        _currentChunk.MarkLabel(continueLabel);
         int loopStart = _currentChunk.Code.Count;
         EmitExpression(whileExpr.Condition);
 
         int jumpAddress = _currentChunk.Code.Count;
         _currentChunk.Emit(OpCode.JumpIfFalse, whileExpr.Condition.Location, 0);
 
+        var breakLabel = Chunk.NewLabel();
+        _loops.Push(new LoopContext { ContinueLabel = continueLabel, BreakLabel = breakLabel });
         EmitExpression(whileExpr.Body);
+        _loops.Pop();
 
         _currentChunk.Emit(OpCode.Loop, whileExpr.Location, loopStart);
+        _currentChunk.MarkLabel(breakLabel);
         var endOfLoop = _currentChunk.Code.Count;
 
         PatchJump(jumpAddress, endOfLoop);

--- a/Jitzu.Tests/ContinueBreakTests.cs
+++ b/Jitzu.Tests/ContinueBreakTests.cs
@@ -1,0 +1,73 @@
+using Shouldly;
+
+namespace Jitzu.Tests;
+
+public class ContinueBreakTests
+{
+    [Test]
+    public async Task Continue_InRangeFor_SkipsRest()
+    {
+        const string source = """
+                              for i in 0..5 {
+                                  if i == 2 { continue }
+                                  print(i)
+                              }
+                              """;
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("0\n1\n3\n4");
+    }
+
+    [Test]
+    public async Task Break_InRangeFor_ExitsLoop()
+    {
+        const string source = """
+                              for i in 0..10 {
+                                  if i == 3 { break }
+                                  print(i)
+                              }
+                              print("done")
+                              """;
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("0\n1\n2\ndone");
+    }
+
+    [Test]
+    public async Task Continue_InCollectionFor_SkipsRest()
+    {
+        const string source = """
+                              let xs = [1, 2, 3, 4]
+                              for x in xs {
+                                  if x == 3 { continue }
+                                  print(x)
+                              }
+                              """;
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("1\n2\n4");
+    }
+
+    [Test]
+    public async Task Break_InWhile_ExitsLoop()
+    {
+        const string source = """
+                              let mut i = 0
+                              while i < 10 {
+                                  if i == 4 { break }
+                                  print(i)
+                                  i++
+                              }
+                              print("done")
+                              """;
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("0\n1\n2\n3\ndone");
+    }
+
+    [Test]
+    public async Task Continue_OutsideLoop_FailsAtCompile()
+    {
+        const string source = """
+                              continue
+                              """;
+        await Should.ThrowAsync<InvalidOperationException>(
+            async () => await InterpreterTestHarness.RunAsync(source));
+    }
+}


### PR DESCRIPTION
Refs #15.

## Summary
`continue` and `break` were lexed but the parser threw `NotImplementedException` for them. Now they parse, compile, and execute in both `for` and `while` loops.

Implementation:
- New `ContinueExpression` / `BreakExpression` AST nodes
- Parser branch in `ParsePrimaryExpression`
- `LoopContext` stack in the bytecode compiler with two `Label`s:
  - `ContinueLabel` — marked at the loop's continue target (the increment block for `for`, the loop top for `while`). Back-patched via `Label` so a `continue` emitted before that point still resolves correctly.
  - `BreakLabel` — marked after the loop's back-edge so `break` exits the loop.
- `continue` / `break` outside a loop throw at compile time.

Spotted while running the same `bootstrap.jz` script from #14 — it uses `continue` to skip iterations.

## Test plan
- [x] `ContinueBreakTests` cover continue/break in range-for, collection-for, while; and an outside-loop error case
- [x] Full suite: 268 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)