### PR TITLE
Lex !=, >= and add OpCode.Neq; enable else-if chaining

### DIFF
--- a/Jitzu.Core/Lexer.cs
+++ b/Jitzu.Core/Lexer.cs
@@ -565,6 +565,8 @@ public ref struct Lexer(ReadOnlySpan<char> filePath, ReadOnlySpan<char> input, i
         {
             ('<', '=') => "<=",
             ('<', '>') => "<>",
+            ('>', '=') => ">=",
+            ('!', '=') => "!=",
             ('+', '+') => "++",
             ('+', '=') => "+=",
             ('-', '-') => "--",

--- a/Jitzu.Core/Runtime/BinaryExpressionEvaluator.cs
+++ b/Jitzu.Core/Runtime/BinaryExpressionEvaluator.cs
@@ -7,6 +7,20 @@ namespace Jitzu.Core.Runtime;
 public static class BinaryExpressionEvaluator
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Value NotEqual(Value a, Value b) => (a.Kind, b.Kind) switch
+    {
+        (ValueKind.Int, ValueKind.Int) => Value.FromBool(a.I32 != b.I32),
+        (ValueKind.Int, ValueKind.Double) => Value.FromBool(a.I32 != b.F64),
+        (ValueKind.Double, ValueKind.Int) => Value.FromBool(a.F64 != b.I32),
+        (ValueKind.Double, ValueKind.Double) => Value.FromBool(a.F64 != b.F64),
+        (ValueKind.Bool, ValueKind.Bool) => Value.FromBool(a.B != b.B),
+        (ValueKind.Null, ValueKind.Null) => Value.FromBool(false),
+        (ValueKind.Null, _) or (_, ValueKind.Null) => Value.FromBool(true),
+        (ValueKind.Ref, ValueKind.Ref) => Value.FromBool(!Equals(a.Ref, b.Ref)),
+        _ => Value.FromBool(true)
+    };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Value Equal(Value a, Value b) => (a.Kind, b.Kind) switch
     {
         (ValueKind.Int, ValueKind.Int) => Value.FromBool(a.I32 == b.I32),

--- a/Jitzu.Core/Runtime/ByteCodeInterpreter.cs
+++ b/Jitzu.Core/Runtime/ByteCodeInterpreter.cs
@@ -267,6 +267,14 @@ public ref struct ByteCodeInterpreter
                         break;
                     }
 
+                    case OpCode.Neq:
+                    {
+                        var right = _programStack.Pop();
+                        var left = _programStack.Pop();
+                        _programStack.Push(BinaryExpressionEvaluator.NotEqual(left, right));
+                        break;
+                    }
+
                     case OpCode.Compare:
                     {
                         EvaluateCompare();

--- a/Jitzu.Core/Runtime/Compilation/ByteCodeCompiler.cs
+++ b/Jitzu.Core/Runtime/Compilation/ByteCodeCompiler.cs
@@ -190,6 +190,7 @@ public sealed class ByteCodeCompiler(RuntimeProgram program)
                     ">=" => OpCode.Gte,
                     "is" => OpCode.Compare,
                     "==" => OpCode.Eq,
+                    "!=" => OpCode.Neq,
                     "%" => OpCode.Mod,
                     "|" => OpCode.BitwiseOr,
                     _ => throw new UnsupportedExpressionException(binOp),
@@ -702,19 +703,24 @@ public sealed class ByteCodeCompiler(RuntimeProgram program)
     private void CompileIfExpression(IfExpression ifExpression)
     {
         EmitExpression(ifExpression.Condition);
-        int jumpOpAddress = _currentChunk.Code.Count;
+        int jumpIfFalseAddress = _currentChunk.Code.Count;
         _currentChunk.Emit(OpCode.JumpIfFalse, ifExpression.Condition.Location, 0);
 
         EmitExpression(ifExpression.Then);
 
         if (ifExpression.Else is null)
         {
-            PatchJump(jumpOpAddress, _currentChunk.Code.Count);
+            PatchJump(jumpIfFalseAddress, _currentChunk.Code.Count);
             return;
         }
 
-        PatchJump(jumpOpAddress, _currentChunk.Code.Count);
+        // Skip over the else branch when the then branch was taken.
+        int jumpOverElseAddress = _currentChunk.Code.Count;
+        _currentChunk.Emit(OpCode.Jump, ifExpression.Location, 0);
+
+        PatchJump(jumpIfFalseAddress, _currentChunk.Code.Count);
         EmitExpression(ifExpression.Else);
+        PatchJump(jumpOverElseAddress, _currentChunk.Code.Count);
     }
 
     private void EmitBlockBody(BlockBodyExpression body)

--- a/Jitzu.Core/Runtime/OpCode.cs
+++ b/Jitzu.Core/Runtime/OpCode.cs
@@ -51,4 +51,5 @@ public enum OpCode : byte
     MakeClosure,
     IndexGetDirect,
     NewList,
+    Neq,
 }

--- a/Jitzu.Tests/NotEqualAndElseIfTests.cs
+++ b/Jitzu.Tests/NotEqualAndElseIfTests.cs
@@ -1,0 +1,44 @@
+using Shouldly;
+
+namespace Jitzu.Tests;
+
+public class NotEqualAndElseIfTests
+{
+    [Test]
+    public async Task NotEqual_Ints()
+    {
+        const string source = """
+                              if 1 != 2 { print("yes") }
+                              if 2 != 2 { print("no") }
+                              """;
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("yes");
+    }
+
+    [Test]
+    public async Task NotEqual_GreaterThanOrEqual()
+    {
+        const string source = """
+                              if 5 >= 5 { print("ok") }
+                              """;
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("ok");
+    }
+
+    [Test]
+    public async Task ElseIf_ChainsCorrectly()
+    {
+        const string source = """
+                              let x = 2
+                              if x == 1 {
+                                  print("one")
+                              } else if x == 2 {
+                                  print("two")
+                              } else {
+                                  print("other")
+                              }
+                              """;
+        var output = await InterpreterTestHarness.RunAsync(source);
+        output.ShouldBe("two");
+    }
+}


### PR DESCRIPTION
Three blockers surfaced trying to use `else if r != null { ... }`:

## Summary
1. **Lexer** didn't pair `!=` or `>=` — they tokenised as two separate operators. Added them alongside the existing `<=`, `==`, `=>` etc.
2. **`!=` had no opcode**: the precedence table mentioned it but the bytecode compiler had no mapping. Added `OpCode.Neq`, wired it in the compiler, and added `BinaryExpressionEvaluator.NotEqual` covering Int/Double/Bool/Null/Ref.
3. **`if/else` codegen** never emitted an unconditional jump over the else branch, so `if cond { A } else { B }` ran both A and B when cond was true. Same fix as in #18 — this branch needs it for the else-if chaining test to pass.

The parser already recursed into `ParseIfExpression` after `else if`, so once the lex/codegen issues were fixed the chaining "just works."

## Overlap with #18
The `CompileIfExpression` change in this PR is identical to the one in #18. Whichever lands first, the other will be a no-op merge.

## Test plan
- [x] `NotEqualAndElseIfTests` cover `!=` on ints, `>=`, and a 3-arm `if / else if / else`
- [x] Full suite: 266 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)