### PR TITLE
Skip NuGet resolution for #:package tags without a version

### DIFF
--- a/Jitzu.Core/Runtime/Compilation/ProgramBuilder.cs
+++ b/Jitzu.Core/Runtime/Compilation/ProgramBuilder.cs
@@ -83,9 +83,14 @@ public static class ProgramBuilder
     {
         foreach (var expression in ast.Body.OfType<TagExpression>())
         {
+            // No version → assume the namespace is in an already-loaded BCL assembly
+            // (e.g. `#:package System.Diagnostics.Process`). Skip NuGet resolution.
+            if (string.IsNullOrEmpty(expression.Version))
+                continue;
+
             var paths = await Resolver.ResolveAsync(
                 expression.Identifier,
-                new NuGetVersion(expression.Version!),
+                new NuGetVersion(expression.Version),
                 Framework);
 
             foreach (var path in paths)


### PR DESCRIPTION
A bare \`#:package System.Diagnostics.Process\` (no version) crashed with \`ArgumentException: Value cannot be null or an empty string\` inside \`NuGetVersion.Parse\`. \`TagExpression.Version\` is already nullable, but the program builder force-unwrapped it.

Skip NuGet resolution when the version is null/empty — those tags refer to BCL namespaces already loaded by the runtime. A clearer diagnostic comes later if a type fails to bind, rather than a stack trace from NuGet internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)