### PR TITLE
Add who built-in for process and file-lock inspection

### DIFF
--- a/Jitzu.Shell/Core/BuiltinCommands.cs
+++ b/Jitzu.Shell/Core/BuiltinCommands.cs
@@ -78,6 +78,7 @@ public class BuiltinCommands
         var statCommand = new StatCommand(_context);
         var chmodCommand = new ChmodCommand(_context);
         var whoamiCommand = new WhoamiCommand(_context);
+        var whoCommand = new WhoCommand(_context);
         var hostnameCommand = new HostnameCommand(_context);
         var uptimeCommand = new UptimeCommand(_context);
         var sleepCommand = new SleepCommand(_context);
@@ -157,6 +158,7 @@ public class BuiltinCommands
             ["stat"] = statCommand.ExecuteAsync,
             ["chmod"] = chmodCommand.ExecuteAsync,
             ["whoami"] = whoamiCommand.ExecuteAsync,
+            ["who"] = whoCommand.ExecuteAsync,
             ["hostname"] = hostnameCommand.ExecuteAsync,
             ["uptime"] = uptimeCommand.ExecuteAsync,
             ["sleep"] = sleepCommand.ExecuteAsync,

--- a/Jitzu.Shell/Core/Commands/WhoCommand.cs
+++ b/Jitzu.Shell/Core/Commands/WhoCommand.cs
@@ -1,0 +1,193 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Jitzu.Shell.Core.Commands;
+
+/// <summary>
+/// Inspects a process by PID, or lists processes locking a file path.
+/// </summary>
+public class WhoCommand : CommandBase
+{
+    public WhoCommand(CommandContext context) : base(context) { }
+
+    public override async Task<ShellResult> ExecuteAsync(ReadOnlyMemory<string> args)
+    {
+        if (args.Length == 0)
+            return new ShellResult(ResultType.Error, "", new Exception("Usage: who <pid|file>"));
+
+        var arg = args.Span[0];
+
+        if (int.TryParse(arg, out var pid))
+            return DescribeProcess(pid);
+
+        var path = ExpandPath(arg);
+        if (File.Exists(path) || Directory.Exists(path))
+            return await DescribeFileLocksAsync(path);
+
+        return new ShellResult(ResultType.Error, "", new Exception($"who: '{arg}' is not a PID or existing path"));
+    }
+
+    private ShellResult DescribeProcess(int pid)
+    {
+        try
+        {
+            var p = Process.GetProcessById(pid);
+            var sb = new StringBuilder();
+            var label = Theme["ls.config"];
+            var reset = ThemeConfig.Reset;
+
+            sb.AppendLine($"{label}    PID:{reset} {p.Id}");
+            sb.AppendLine($"{label}   Name:{reset} {p.ProcessName}");
+
+            string? path = null;
+            string? args = null;
+            try { path = p.MainModule?.FileName; } catch { }
+            if (path is null && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var exeLink = $"/proc/{pid}/exe";
+                try { path = File.ResolveLinkTarget(exeLink, true)?.FullName; } catch { }
+            }
+            if (path is not null)
+                sb.AppendLine($"{label}   Path:{reset} {path}");
+
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                try
+                {
+                    var cmdline = File.ReadAllText($"/proc/{pid}/cmdline");
+                    args = cmdline.Replace('\0', ' ').Trim();
+                }
+                catch { }
+            }
+            if (!string.IsNullOrEmpty(args))
+                sb.AppendLine($"{label}   Args:{reset} {args}");
+
+            try { sb.AppendLine($"{label}Started:{reset} {p.StartTime:yyyy-MM-dd HH:mm:ss}"); } catch { }
+            try { sb.AppendLine($"{label}    CPU:{reset} {p.TotalProcessorTime}"); } catch { }
+            try { sb.AppendLine($"{label} Memory:{reset} {FormatFileSize(p.WorkingSet64)}"); } catch { }
+            try { sb.AppendLine($"{label}Threads:{reset} {p.Threads.Count}"); } catch { }
+
+            return new ShellResult(ResultType.OsCommand, sb.ToString().TrimEnd(), null);
+        }
+        catch (ArgumentException)
+        {
+            return new ShellResult(ResultType.Error, "", new Exception($"who: no process with pid {pid}"));
+        }
+        catch (Exception ex)
+        {
+            return new ShellResult(ResultType.Error, "", ex);
+        }
+    }
+
+    private async Task<ShellResult> DescribeFileLocksAsync(string path)
+    {
+        try
+        {
+            List<(int Pid, string Name)> holders;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                holders = WhoWindowsLocks.GetProcessesLockingFile(path);
+            else
+                holders = await GetProcessesLockingFileUnixAsync(path);
+
+            if (holders.Count == 0)
+                return new ShellResult(ResultType.OsCommand, $"No processes hold a lock on '{path}'.", null);
+
+            var sb = new StringBuilder();
+            var label = Theme["ls.config"];
+            var reset = ThemeConfig.Reset;
+            sb.AppendLine($"{label}File:{reset} {path}");
+            sb.AppendLine($"{label}Held by {holders.Count} process(es):{reset}");
+            foreach (var (hpid, hname) in holders)
+                sb.AppendLine($"  {hpid,8}  {hname}");
+
+            return new ShellResult(ResultType.OsCommand, sb.ToString().TrimEnd(), null);
+        }
+        catch (Exception ex)
+        {
+            return new ShellResult(ResultType.Error, "", ex);
+        }
+    }
+
+    private static async Task<List<(int Pid, string Name)>> GetProcessesLockingFileUnixAsync(string path)
+    {
+        var result = new List<(int, string)>();
+
+        // Prefer /proc scan on Linux (no external deps); fall back to lsof.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && Directory.Exists("/proc"))
+        {
+            var target = Path.GetFullPath(path);
+            foreach (var procDir in Directory.EnumerateDirectories("/proc"))
+            {
+                var name = Path.GetFileName(procDir);
+                if (!int.TryParse(name, out var pid)) continue;
+
+                var fdDir = Path.Combine(procDir, "fd");
+                try
+                {
+                    foreach (var fd in Directory.EnumerateFiles(fdDir))
+                    {
+                        try
+                        {
+                            var link = File.ResolveLinkTarget(fd, true)?.FullName;
+                            if (link == target)
+                            {
+                                string pname = "?";
+                                try { pname = File.ReadAllText(Path.Combine(procDir, "comm")).Trim(); } catch { }
+                                result.Add((pid, pname));
+                                break;
+                            }
+                        }
+                        catch { }
+                    }
+                }
+                catch { } // permission denied for other users' processes
+            }
+            return result;
+        }
+
+        // macOS / fallback: lsof
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "lsof",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add("-Fpcn");
+            psi.ArgumentList.Add("--");
+            psi.ArgumentList.Add(path);
+
+            using var proc = Process.Start(psi);
+            if (proc is null) return result;
+            var output = await proc.StandardOutput.ReadToEndAsync();
+            await proc.WaitForExitAsync();
+
+            int curPid = 0;
+            string curName = "";
+            foreach (var line in output.Split('\n'))
+            {
+                if (line.Length < 2) continue;
+                switch (line[0])
+                {
+                    case 'p':
+                        if (curPid != 0) result.Add((curPid, curName));
+                        int.TryParse(line.AsSpan(1), out curPid);
+                        curName = "";
+                        break;
+                    case 'c':
+                        curName = line[1..];
+                        break;
+                }
+            }
+            if (curPid != 0) result.Add((curPid, curName));
+        }
+        catch { }
+
+        return result;
+    }
+}

--- a/Jitzu.Shell/Core/Commands/WhoWindowsLocks.cs
+++ b/Jitzu.Shell/Core/Commands/WhoWindowsLocks.cs
@@ -1,0 +1,122 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace Jitzu.Shell.Core.Commands;
+
+/// <summary>
+/// Uses the Windows Restart Manager to enumerate processes holding handles to a file.
+/// </summary>
+internal static class WhoWindowsLocks
+{
+    public static List<(int Pid, string Name)> GetProcessesLockingFile(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+            return new();
+        return GetProcessesLockingFileWindows(path);
+    }
+
+    private const int CCH_RM_MAX_APP_NAME = 255;
+    private const int CCH_RM_MAX_SVC_NAME = 63;
+    private const int RmRebootReasonNone = 0;
+    private const int ERROR_MORE_DATA = 234;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RM_UNIQUE_PROCESS
+    {
+        public int dwProcessId;
+        public System.Runtime.InteropServices.ComTypes.FILETIME ProcessStartTime;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct RM_PROCESS_INFO
+    {
+        public RM_UNIQUE_PROCESS Process;
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCH_RM_MAX_APP_NAME + 1)]
+        public string strAppName;
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCH_RM_MAX_SVC_NAME + 1)]
+        public string strServiceShortName;
+
+        public int ApplicationType;
+        public uint AppStatus;
+        public uint TSSessionId;
+
+        [MarshalAs(UnmanagedType.Bool)]
+        public bool bRestartable;
+    }
+
+    [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)]
+    private static extern int RmStartSession(out uint pSessionHandle, int dwSessionFlags, string strSessionKey);
+
+    [DllImport("rstrtmgr.dll")]
+    private static extern int RmEndSession(uint pSessionHandle);
+
+    [DllImport("rstrtmgr.dll", CharSet = CharSet.Unicode)]
+    private static extern int RmRegisterResources(
+        uint pSessionHandle,
+        uint nFiles,
+        string[] rgsFilenames,
+        uint nApplications,
+        [In] RM_UNIQUE_PROCESS[]? rgApplications,
+        uint nServices,
+        string[]? rgsServiceNames);
+
+    [DllImport("rstrtmgr.dll")]
+    private static extern int RmGetList(
+        uint dwSessionHandle,
+        out uint pnProcInfoNeeded,
+        ref uint pnProcInfo,
+        [In, Out] RM_PROCESS_INFO[]? rgAffectedApps,
+        ref uint lpdwRebootReasons);
+
+    [SupportedOSPlatform("windows")]
+    private static List<(int Pid, string Name)> GetProcessesLockingFileWindows(string path)
+    {
+        var results = new List<(int, string)>();
+
+        var key = Guid.NewGuid().ToString();
+        if (RmStartSession(out var session, 0, key) != 0)
+            return results;
+
+        try
+        {
+            if (RmRegisterResources(session, 1, new[] { path }, 0, null, 0, null) != 0)
+                return results;
+
+            uint procInfoNeeded = 0;
+            uint procInfo = 0;
+            uint rebootReasons = RmRebootReasonNone;
+
+            var probe = RmGetList(session, out procInfoNeeded, ref procInfo, null, ref rebootReasons);
+            if (probe != 0 && probe != ERROR_MORE_DATA) return results;
+            if (procInfoNeeded == 0) return results;
+
+            var infoArray = new RM_PROCESS_INFO[procInfoNeeded];
+            procInfo = procInfoNeeded;
+
+            if (RmGetList(session, out procInfoNeeded, ref procInfo, infoArray, ref rebootReasons) != 0)
+                return results;
+
+            for (var i = 0; i < procInfo; i++)
+            {
+                var info = infoArray[i];
+                int pid = info.Process.dwProcessId;
+                var name = info.strAppName;
+                if (string.IsNullOrEmpty(name))
+                {
+                    try { name = Process.GetProcessById(pid).ProcessName; }
+                    catch { name = "?"; }
+                }
+                results.Add((pid, name));
+            }
+        }
+        finally
+        {
+            RmEndSession(session);
+        }
+
+        return results;
+    }
+}

--- a/Jitzu.Tests/WhoCommandTests.cs
+++ b/Jitzu.Tests/WhoCommandTests.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics;
+using Jitzu.Shell;
+using Jitzu.Shell.Core;
+using Jitzu.Shell.Core.Commands;
+using Shouldly;
+
+namespace Jitzu.Tests;
+
+public class WhoCommandTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly WhoCommand _cmd;
+
+    public WhoCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "jitzu_who_test_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+
+        var theme = ThemeConfig.CreateDefault();
+        var context = new CommandContext(new ShellSession(), theme);
+        _cmd = new WhoCommand(context);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    [Test]
+    public async Task Who_NoArgs_ReturnsError()
+    {
+        var result = await _cmd.ExecuteAsync(ReadOnlyMemory<string>.Empty);
+        result.Type.ShouldBe(ResultType.Error);
+    }
+
+    [Test]
+    public async Task Who_OwnPid_DescribesProcess()
+    {
+        var pid = Environment.ProcessId;
+        var result = await _cmd.ExecuteAsync(new[] { pid.ToString() }.AsMemory());
+
+        result.Type.ShouldBe(ResultType.OsCommand);
+        result.Output.ShouldContain(pid.ToString());
+        result.Output.ShouldContain("PID");
+        result.Output.ShouldContain("Name");
+    }
+
+    [Test]
+    public async Task Who_NonexistentPid_ReturnsError()
+    {
+        var result = await _cmd.ExecuteAsync(new[] { "999999999" }.AsMemory());
+        result.Type.ShouldBe(ResultType.Error);
+    }
+
+    [Test]
+    public async Task Who_NonexistentPath_ReturnsError()
+    {
+        var result = await _cmd.ExecuteAsync(new[] { Path.Combine(_tempDir, "nope.txt") }.AsMemory());
+        result.Type.ShouldBe(ResultType.Error);
+    }
+
+    [Test]
+    public async Task Who_UnlockedFile_ReportsNoHolders()
+    {
+        var file = Path.Combine(_tempDir, "free.txt");
+        await File.WriteAllTextAsync(file, "hello");
+
+        var result = await _cmd.ExecuteAsync(new[] { file }.AsMemory());
+
+        result.Type.ShouldBe(ResultType.OsCommand);
+        result.Output.ShouldNotBeNull();
+    }
+
+    [Test]
+    public async Task Who_LockedFile_ReportsHolder()
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsWindows())
+            return;
+
+        var file = Path.Combine(_tempDir, "locked.txt");
+        await File.WriteAllTextAsync(file, "data");
+
+        await using var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+        var result = await _cmd.ExecuteAsync(new[] { file }.AsMemory());
+
+        result.Type.ShouldBe(ResultType.OsCommand);
+        result.Output.ShouldContain(Environment.ProcessId.ToString());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `who <pid>` to describe a process (name, path, args, start time, CPU, memory, threads)
- Adds `who <file>` to list processes holding handles to a file
- Windows: Restart Manager via direct P/Invoke (no PowerToys/Handle.exe needed)
- Linux: scans `/proc/*/fd` (no external deps)
- macOS / fallback: shells out to `lsof`

Closes #25

## Test plan
- [x] `dotnet test` — 296/296 pass (6 new `WhoCommandTests`)
- [ ] Manual: `who <self-pid>` prints process metadata
- [ ] Manual (Windows): open a file in Notepad, `who path/to/file` lists notepad.exe
- [ ] Manual (Linux): `tail -f log` in another shell, `who log` lists tail

🤖 Generated with [Claude Code](https://claude.com/claude-code)