### PR TITLE
Fix Result and Option variants in functions

### DIFF
--- a/Jitzu.Core/Runtime/ByteCodeInterpreter.cs
+++ b/Jitzu.Core/Runtime/ByteCodeInterpreter.cs
@@ -625,6 +625,15 @@ public ref struct ByteCodeInterpreter
             case Type type:
             {
                 var ctorArgs = args.Select(arg => OptionBridge.UnwrapOption(arg.AsObject())).ToArray();
+                if (type.IsGenericTypeDefinition)
+                {
+                    var genericParameters = type.GetGenericArguments();
+                    if (genericParameters.Length != 1 || ctorArgs.Length == 0 || ctorArgs[0] is null)
+                        throw new InvalidOperationException(
+                            $"Cannot infer generic arguments for '{type.Name}' from this constructor call");
+
+                    type = type.MakeGenericType(ctorArgs[0]!.GetType());
+                }
                 _programStack.Push(Activator.CreateInstance(type, ctorArgs)!);
                 break;
             }
@@ -686,7 +695,7 @@ public ref struct ByteCodeInterpreter
             return false;
         }
 
-        returnValue = _programStack.Pop();
+        returnValue = CoerceDeclaredUnionReturn(_programStack.Pop(), _currentFunction.FunctionReturnType);
 
         if (_frameTop < 0)
             return true;
@@ -703,6 +712,24 @@ public ref struct ByteCodeInterpreter
 
         _programStack.Push(returnValue);
         return false;
+    }
+
+    private static Value CoerceDeclaredUnionReturn(Value returnValue, Type? declaredReturnType)
+    {
+        if (declaredReturnType is null
+            || !typeof(IUnion).IsAssignableFrom(declaredReturnType)
+            || returnValue.Kind is not ValueKind.Ref
+            || returnValue.Ref is IUnion)
+            return returnValue;
+
+        var value = returnValue.Ref;
+        var constructor = declaredReturnType.GetConstructors()
+            .FirstOrDefault(c => c.GetParameters() is [{ ParameterType: var parameterType }]
+                                 && parameterType.IsInstanceOfType(value));
+
+        return constructor is null
+            ? returnValue
+            : Value.FromRef(constructor.Invoke([value]));
     }
 
     private void Swap()

--- a/Jitzu.Core/Runtime/Compilation/AstTransformer.cs
+++ b/Jitzu.Core/Runtime/Compilation/AstTransformer.cs
@@ -269,7 +269,7 @@ public class AstTransformer(RuntimeProgram program)
         Type type,
         SlotMapBuilder slotMapBuilder)
     {
-        var local = slotMapBuilder.Add(type.Name);
+        var local = slotMapBuilder.AddGlobal(ident.Name);
         return TransformIdentifierToLocalGet(ident, local);
     }
 

--- a/Jitzu.Core/Runtime/Memory/SlotMapBuilder.cs
+++ b/Jitzu.Core/Runtime/Memory/SlotMapBuilder.cs
@@ -62,6 +62,13 @@ public class SlotMapBuilder(SlotMapBuilder? parentBuilder, LocalKind localKind)
     }
 
     /// <summary>
+    /// Adds a name to the root/global slot map, even when called while binding a
+    /// function or lambda body. Runtime type objects live in global slots and must
+    /// never be allocated as uninitialised function locals.
+    /// </summary>
+    public Local AddGlobal(string name) => parentBuilder?.AddGlobal(name) ?? Add(name);
+
+    /// <summary>
     /// Try to find a local in the current function or enclosing functions.
     /// </summary>
     public bool TryGetLocal(string name, out Local local)

--- a/Jitzu.Tests/Issue15RegressionTests.cs
+++ b/Jitzu.Tests/Issue15RegressionTests.cs
@@ -1,0 +1,115 @@
+using Shouldly;
+
+namespace Jitzu.Tests;
+
+public class Issue15RegressionTests
+{
+    [Test]
+    public async Task MatchArm_BlockBody_Runs()
+    {
+        const string source = """
+                              let result = match 1 {
+                                  1 => { print("side effect"); "matched" },
+                                  _ => "other",
+                              }
+                              print(result)
+                              """;
+
+        var output = await InterpreterTestHarness.RunAsync(source);
+
+        output.ShouldBe("side effect\nmatched");
+    }
+
+    [Test]
+    public async Task Result_CanBeMatchedAndTryUnwrapped()
+    {
+        const string source = """
+                              fun value(): Result<Int, String> {
+                                  return Ok(21)
+                              }
+
+                              let result = value()
+                              let unwrapped = try result
+                              let matched = match result {
+                                  Ok(_) => 1,
+                                  Err(_) => 0,
+                              }
+                              print(unwrapped)
+                              print(matched)
+                              """;
+
+        var output = await InterpreterTestHarness.RunAsync(source);
+
+        output.ShouldBe("21\n1");
+    }
+
+    [Test]
+    public async Task Result_ErrVariant_IsWrappedAndMatched()
+    {
+        const string source = """
+                              fun failure(): Result<Int, String> {
+                                  return Err("nope")
+                              }
+
+                              let result = failure()
+                              let message = match result {
+                                  Ok(_) => "ok",
+                                  Err(_) => "error",
+                              }
+                              print(message)
+                              """;
+
+        var output = await InterpreterTestHarness.RunAsync(source);
+
+        output.ShouldBe("error");
+    }
+
+    [Test]
+    public async Task Option_VariantConstructedInsideFunction_IsWrappedAndMatched()
+    {
+        const string source = """
+                              fun maybe(): Option<Int> {
+                                  return Some(7)
+                              }
+
+                              let result = maybe()
+                              let value = match result {
+                                  Some(_) => 1,
+                                  None => 0,
+                              }
+                              print(value)
+                              """;
+
+        var output = await InterpreterTestHarness.RunAsync(source);
+
+        output.ShouldBe("1");
+    }
+
+    [Test]
+    public async Task BclProcessAndEnumInstanceMethods_Run()
+    {
+        const string source = """
+                              let process = Process.GetCurrentProcess()
+                              print(process.Id > 0)
+                              print(FileAttributes.ReadOnly.HasFlag(FileAttributes.ReadOnly))
+                              """;
+
+        var output = await InterpreterTestHarness.RunAsync(source);
+
+        output.ShouldBe("True\nTrue");
+    }
+
+    [Test]
+    public async Task ForIn_StringArrayLiteral_Runs()
+    {
+        const string source = """
+                              for item in ["a", "b"] {
+                                  print(item)
+                              }
+                              """;
+
+        var output = await InterpreterTestHarness.RunAsync(source);
+
+        output.ShouldBe("a\nb");
+    }
+}


### PR DESCRIPTION
## Summary

- keep runtime type references in global slots when they are used inside functions or lambdas
- infer the single generic argument for variant constructors such as `Ok`, `Err`, and `Some`
- wrap returned variants into a function's declared `Result<T, E>` or `Option<T>` union
- add regression coverage for every gap tracked in #15

## Root cause

The transformer allocated type objects referenced from function bodies as uninitialised local slots. Once variant construction worked, the interpreter still returned raw `Ok<T>`/`Err<T>`/`Some<T>` values instead of coercing them to the declared union return type, so `try` and union matching could not consume them.

## Impact

Functions can now return Result and Option variants that work with `try` and `match`. The other unverified #15 scenarios are locked in by end-to-end tests.

## Validation

- `dotnet test Jitzu.Tests/Jitzu.Tests.csproj --treenode-filter "/*/*/Issue15RegressionTests/**"` (6 passed)
- `dotnet test` (358 passed)
- `git diff --check`

Closes #15
