### PR TITLE
Hide VM internals from runtime errors

### DIFF
--- a/Jitzu.Core/Logging/ValueFormatter.cs
+++ b/Jitzu.Core/Logging/ValueFormatter.cs
@@ -10,6 +10,26 @@ namespace Jitzu.Core.Logging;
 
 public static class ValueFormatter 
 {
+    public static string FormatTypeName(Value? value)
+    {
+        if (value is not { } v)
+            return "None";
+
+        return v.Kind switch
+        {
+            ValueKind.Null => "None",
+            ValueKind.Int => "Int",
+            ValueKind.Double => "Double",
+            ValueKind.Bool => "Bool",
+            ValueKind.Ref when v.Ref is string => "String",
+            ValueKind.Ref => TrimGenericArity(v.Ref.GetType().Name),
+            _ => v.Kind.ToString()
+        };
+    }
+
+    private static string TrimGenericArity(string name) =>
+        name.IndexOf('`') is var index and >= 0 ? name[..index] : name;
+
     public static string? Format(params object?[] objects)
     {
         switch (objects.Length)

--- a/Jitzu.Core/Runtime/BinaryExpressionEvaluator.cs
+++ b/Jitzu.Core/Runtime/BinaryExpressionEvaluator.cs
@@ -178,4 +178,4 @@ public static class BinaryExpressionEvaluator
 }
 
 public class OperationNotSupportedException(string op, Value left, Value? right) : Exception(
-    $"Operation {op} not supported for types '{ValueFormatter.Format(left)}' and '{ValueFormatter.Format(right)}'");
+    $"Operation {op} not supported for types '{ValueFormatter.FormatTypeName(left)}' and '{ValueFormatter.FormatTypeName(right)}'");

--- a/Jitzu.Core/Runtime/ByteCodeInterpreter.cs
+++ b/Jitzu.Core/Runtime/ByteCodeInterpreter.cs
@@ -376,17 +376,18 @@ public ref struct ByteCodeInterpreter
         }
         catch (Exception ex)
         {
-            Console.WriteLine("Error occured at IP: {0}", _ip);
-            Console.WriteLine("Stack:");
-            if (_programStack.StackPointer > -1)
+            if (_dumpStack)
             {
-                foreach (var item in _programStack.Stack[.._programStack.StackPointer])
-                    Console.WriteLine($"- {item}");
-            }
+                var output = GlobalFunctions.Output;
+                output.WriteLine("Error occurred at IP: {0}", _ip);
+                output.WriteLine("Stack:");
+                for (var i = 0; i <= _programStack.StackPointer; i++)
+                    output.WriteLine($"- {_programStack.Stack[i]}");
 
-            Console.WriteLine($"FrameTop={_frameTop}");
-            for (var i = 0; i <= _frameTop; i++)
-                Console.WriteLine($"[{i}] {_frames[i].UserFunction.ToString()} IP={_frames[i].IP}");
+                output.WriteLine($"FrameTop={_frameTop}");
+                for (var i = 0; i <= _frameTop; i++)
+                    output.WriteLine($"[{i}] {_frames[i].UserFunction} IP={_frames[i].IP}");
+            }
 
             var debugSpan = _currentFunction.Chunk.DebugSpans[lastIp];
             throw new JitzuException(debugSpan, ex.Message);
@@ -410,7 +411,7 @@ public ref struct ByteCodeInterpreter
                 sb.Append($"[{ValueFormatter.Format(_programStack.Peek(i))}]");
             }
 
-            Console.WriteLine($"{_ip:000}: {sb}");
+            GlobalFunctions.Output.WriteLine($"{_ip:000}: {sb}");
         }
         finally
         {

--- a/Jitzu.Tests/RuntimeDiagnosticTests.cs
+++ b/Jitzu.Tests/RuntimeDiagnosticTests.cs
@@ -1,0 +1,84 @@
+using Jitzu.Core;
+using Jitzu.Core.Language;
+using Jitzu.Core.Runtime;
+using Jitzu.Core.Runtime.Compilation;
+using Shouldly;
+
+namespace Jitzu.Tests;
+
+public class RuntimeDiagnosticTests
+{
+    [Test]
+    public async Task RuntimeFailure_HidesVmStateWithoutDebug()
+    {
+        var (error, diagnostic) = await RunFailure(debug: false);
+
+        diagnostic.ShouldBeEmpty();
+        error.Message.ShouldContain("types 'Bool' and 'Bool'");
+        error.Message.ShouldNotContain("Value(");
+    }
+
+    [Test]
+    public async Task RuntimeFailure_ShowsVmStateInDebugMode()
+    {
+        var (error, diagnostic) = await RunFailure(debug: true);
+
+        diagnostic.ShouldContain("Error occurred at IP:");
+        diagnostic.ShouldContain("Stack:");
+        diagnostic.ShouldContain("FrameTop=");
+        error.Message.ShouldContain("types 'Bool' and 'Bool'");
+    }
+
+    [Test]
+    public void UnsupportedOperation_DoesNotExposeReferenceValue()
+    {
+        var left = Value.FromRef(new SensitiveValue("top-secret"));
+
+        var error = Should.Throw<OperationNotSupportedException>(
+            () => BinaryExpressionEvaluator.Add(left, Value.FromInt(1)));
+
+        error.Message.ShouldContain("types 'SensitiveValue' and 'Int'");
+        error.Message.ShouldNotContain("top-secret");
+        error.Message.ShouldNotContain("Value(");
+    }
+
+    private static async Task<(JitzuException Error, string Diagnostic)> RunFailure(bool debug)
+    {
+        var ast = new ScriptExpression
+        {
+            Body = Parser.Parse("diagnostic.jz", "true + false")
+        };
+
+        var program = await ProgramBuilder.Build(ast);
+        ast = new SemanticAnalyser(program).AnalyseScript(ast);
+        var script = new ByteCodeCompiler(program).Compile(ast.Body);
+
+        using var writer = new StringWriter { NewLine = "\n" };
+        GlobalFunctions.SetOutput(writer);
+        try
+        {
+            var interpreter = new ByteCodeInterpreter(program, script, [], debug);
+            JitzuException? error = null;
+            try
+            {
+                interpreter.Evaluate();
+            }
+            catch (JitzuException ex)
+            {
+                error = ex;
+            }
+
+            error.ShouldNotBeNull();
+            return (error, writer.ToString());
+        }
+        finally
+        {
+            GlobalFunctions.SetOutput(null);
+        }
+    }
+
+    private sealed record SensitiveValue(string Value)
+    {
+        public override string ToString() => Value;
+    }
+}


### PR DESCRIPTION
## Summary

- report language-facing value types (`String`, `Int`, `Bool`, and so on) without formatting their values
- hide instruction-pointer, operand-stack, and frame details during normal execution
- retain the VM diagnostics when `--debug` is enabled
- route debug diagnostics through the runtime output abstraction for consistent capture

## Root cause

Unsupported operations built their messages with the general value formatter, which includes both the internal `Value(...)` representation and the underlying value. The interpreter's exception handler also printed VM state unconditionally, ignoring the existing debug flag.

## Impact

Runtime failures no longer expose VM implementation details or reference values to normal script users. Debug mode still supplies the low-level information needed for diagnosis.

## Validation

- `dotnet test Jitzu.Tests/Jitzu.Tests.csproj --treenode-filter "/*/*/RuntimeDiagnosticTests/**"` (3 passed)
- isolated performance regression check (1 passed after a transient full-suite timeout)
- `dotnet test --no-restore` (355 passed)
- `git diff --check`

Closes #6
