### PR TITLE
Explain missing function parameter types

### DIFF
--- a/Jitzu.Core/Parser.cs
+++ b/Jitzu.Core/Parser.cs
@@ -902,7 +902,7 @@ public ref struct Parser(ReadOnlySpan<Token> tokens)
             { } other => throw new Exception("Expected single identifier, got " + ExpressionFormatter.Format(other))
         };
 
-        var parameters = ParseFunctionParameters();
+        var parameters = ParseFunctionParameters(identifier.Name);
         var returnType = ParseFunctionReturnType();
         var body = ParseBlockBodyExpression();
 
@@ -1069,7 +1069,7 @@ public ref struct Parser(ReadOnlySpan<Token> tokens)
 
                     MoveNext();
                     var funName = ParseIdentifierLiteral();
-                    var parameters = ParseFunctionParameters();
+                    var parameters = ParseFunctionParameters(funName.Name);
                     var returnType = ParseFunctionReturnType();
 
                     functions.Add(
@@ -1442,7 +1442,7 @@ public ref struct Parser(ReadOnlySpan<Token> tokens)
         };
     }
 
-    private FunctionParametersExpression ParseFunctionParameters()
+    private FunctionParametersExpression ParseFunctionParameters(string functionName)
     {
         var openParen = ExpectAndConsume('(');
         var builder = ImmutableArray.CreateBuilder<FunctionParameterExpression>();
@@ -1466,7 +1466,11 @@ public ref struct Parser(ReadOnlySpan<Token> tokens)
                 continue;
             }
 
-            ExpectAndConsume(':');
+            if (!TryConsume(':'))
+                throw new MissingParameterTypeAnnotationException(
+                    nameIdentifier.Span,
+                    functionName,
+                    nameIdentifier.Value);
 
             var type = ParseTypeAnnotation();
 
@@ -1713,3 +1717,12 @@ public class UnexpectedSyntaxException(
     ReadOnlySpan<char> expected,
     ReadOnlySpan<char> received
 ) : JitzuException(location, $"S002: Syntax Error - Expected {expected} but got {received}");
+
+public class MissingParameterTypeAnnotationException(
+    SourceSpan location,
+    string functionName,
+    string parameterName
+) : JitzuException(
+    location,
+    $"S002: Syntax Error - Function parameter '{parameterName}' requires a type annotation. " +
+    $"Example: fun {functionName}({parameterName}: Int) {{ ... }}");

--- a/Jitzu.Tests/FunctionParameterDiagnosticTests.cs
+++ b/Jitzu.Tests/FunctionParameterDiagnosticTests.cs
@@ -1,0 +1,38 @@
+using Jitzu.Core;
+using Shouldly;
+
+namespace Jitzu.Tests;
+
+public class FunctionParameterDiagnosticTests
+{
+    [Test]
+    public void UntypedParameter_ExplainsRequiredAnnotation()
+    {
+        const string source = """
+                              fun double(n) {
+                                  return n * 2
+                              }
+                              """;
+
+        var error = Should.Throw<MissingParameterTypeAnnotationException>(
+            () => Parser.Parse("script.jz", source));
+
+        error.Message.ShouldBe(
+            "S002: Syntax Error - Function parameter 'n' requires a type annotation. " +
+            "Example: fun double(n: Int) { ... }");
+        error.Location.Start.Line.ShouldBe(1);
+        error.Location.Start.Column.ShouldBe(12);
+    }
+
+    [Test]
+    public void LaterUntypedParameter_NamesTheCorrectParameter()
+    {
+        const string source = "fun pair(first: Int, second) { first }";
+
+        var error = Should.Throw<MissingParameterTypeAnnotationException>(
+            () => Parser.Parse("script.jz", source));
+
+        error.Message.ShouldContain("parameter 'second'");
+        error.Message.ShouldContain("fun pair(second: Int)");
+    }
+}


### PR DESCRIPTION
## Summary

- detect a missing function-parameter type annotation at the parameter itself
- name both the function and offending parameter in the syntax error
- include a valid typed-parameter example in the diagnostic
- cover first and later untyped parameters with parser tests

## Root cause

Parameter parsing delegated directly to the generic `ExpectAndConsume(':')` path. That preserved the token mismatch but discarded the grammatical context, leaving users with only `Expected : but got Operator )`.

## Impact

An untyped parameter such as `fun double(n)` now explains that `n` requires a type annotation and shows `fun double(n: Int) { ... }`.

## Validation

- `dotnet test Jitzu.Tests/Jitzu.Tests.csproj --treenode-filter "/*/*/FunctionParameterDiagnosticTests/**"` (2 passed)
- `dotnet test --no-restore` (354 passed)
- `git diff --check`

Closes #7
