### PR TITLE
Fix Windows installation guidance

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,6 +24,9 @@ Jitzu is a lightweight, expressive scripting language that runs on the .NET runt
 ### Package Managers
 
 ```sh
+# Windows (WinGet)
+winget install --id JitzuLang.Jitzu --exact
+
 # Windows (Scoop)
 scoop bucket add jitzu https://github.com/jitzulang/jitzu
 scoop install jz

--- a/site/src/content/docs/getting-started/installation.mdx
+++ b/site/src/content/docs/getting-started/installation.mdx
@@ -15,9 +15,15 @@ Jitzu is distributed as a single standalone binary — `jz` — that serves as b
 
 ## Package Managers
 
+### Windows (WinGet)
+
+WinGet is included with current versions of Windows 10 and Windows 11.
+
+<CodeBlock language="powershell" code={`winget install --id JitzuLang.Jitzu --exact`} />
+
 ### Windows (Scoop)
 
-<CodeBlock language="bash" code={`scoop bucket add jitzu https://github.com/jitzulang/jitzu
+<CodeBlock language="powershell" code={`scoop bucket add jitzu https://github.com/jitzulang/jitzu
 scoop install jz`} />
 
 ## Self-Contained Binary
@@ -27,14 +33,23 @@ prerequisites. This is the easiest way to get started without a package manager.
 
 ### Windows
 
-Download `jitzu-win-x64.zip` from the [latest GitHub release](https://github.com/jitzulang/jitzu/releases/latest) and extract it. Add the extracted directory to your PATH, or move the binary to a directory already on your PATH.
+Download `jitzu-win-x64.zip` from the [latest GitHub release](https://github.com/jitzulang/jitzu/releases/latest). The following PowerShell commands extract it to a user-owned application directory and add that directory to your persistent user PATH without requiring administrator access.
 
-<CodeBlock language="bash" code={`# PowerShell
-Expand-Archive jitzu-win-x64.zip -DestinationPath C:\\tools\\jitzu
-$env:PATH += ";C:\\tools\\jitzu"
+<CodeBlock language="powershell" code={`$dest = Join-Path $env:LOCALAPPDATA "Programs\\Jitzu"
+New-Item -ItemType Directory -Force -Path $dest | Out-Null
+Expand-Archive .\\jitzu-win-x64.zip -DestinationPath $dest -Force
 
-# Or move to a directory already on PATH
-Move-Item jz.exe C:\\Windows\\`} />
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$pathEntries = @($userPath -split ";" | Where-Object { $_ })
+if ($pathEntries -notcontains $dest) {
+    [Environment]::SetEnvironmentVariable(
+        "Path",
+        ($pathEntries + $dest) -join ";",
+        "User"
+    )
+}`} />
+
+Restart your terminal after updating PATH, then run `jz --version` to verify the installation.
 
 ### macOS
 


### PR DESCRIPTION
## Summary

- list WinGet as the first Windows package-manager option in both the README and site docs
- replace the session-only PATH mutation with a persistent, idempotent user PATH update
- extract manual installs under `%LOCALAPPDATA%\Programs\Jitzu` without administrator access
- remove the recommendation to copy `jz.exe` into `C:\Windows`

## Root cause

The site documentation predated the published WinGet package and used `$env:PATH += ...`, which only affects the current PowerShell process. It also selected system-oriented destinations that were unnecessary for a per-user portable binary.

## Impact

Windows users can install through the built-in package manager or follow manual steps that survive terminal restarts and do not require elevation.

## Validation

- `winget show --id JitzuLang.Jitzu --exact --accept-source-agreements`
- verified the package in `microsoft/winget-pkgs` via `gh api`
- parsed the documented PowerShell as a script block
- `npm run build` in `site` (29 pages built)
- verified rendered installation HTML contains WinGet and persistent PATH guidance
- verified legacy `C:\tools\jitzu`, `C:\Windows`, and session-only PATH instructions are absent
- `git diff --check`

Closes #1
Closes #2
