### PR TITLE
Add pipeline file mapping and aggregations

### DIFF
--- a/Jitzu.Shell/Core/ExecutionStrategy.cs
+++ b/Jitzu.Shell/Core/ExecutionStrategy.cs
@@ -16,7 +16,11 @@ namespace Jitzu.Shell.Core;
 /// </summary>
 public class ExecutionStrategy(ShellSession session, BuiltinCommands builtins, AliasManager? aliasManager = null, LabelManager? labelManager = null)
 {
-    private static readonly HashSet<string> PipeFunctions = ["first", "last", "nth", "grep", "print", "head", "tail", "sort", "uniq", "wc", "more", "less", "tee"];
+    private static readonly HashSet<string> PipeFunctions =
+    [
+        "first", "last", "nth", "grep", "print", "head", "tail", "sort", "uniq", "wc",
+        "sum", "avg", "min", "max", "count", "more", "less", "tee"
+    ];
 
     private readonly List<BackgroundJob> _jobs = [];
     private int _nextJobId = 1;
@@ -1551,7 +1555,13 @@ public class ExecutionStrategy(ShellSession session, BuiltinCommands builtins, A
                 linesOnly: args.Any(a => a is "-l" or "--lines"),
                 wordsOnly: args.Any(a => a is "-w" or "--words"),
                 charsOnly: args.Any(a => a is "-c" or "--chars"),
+                files: args.Any(a => a is "--files" or "--each-file"),
                 cancellationToken),
+            "sum" => StreamingPipeFunctions.SumAsync(stream, cancellationToken),
+            "avg" => StreamingPipeFunctions.AverageAsync(stream, cancellationToken),
+            "min" => StreamingPipeFunctions.MinAsync(stream, cancellationToken),
+            "max" => StreamingPipeFunctions.MaxAsync(stream, cancellationToken),
+            "count" => StreamingPipeFunctions.CountAsync(stream, cancellationToken),
             "print" => PrintStreamAsync(stream, cancellationToken),
             "tee" => StreamingPipeFunctions.TeeAsync(stream, args.Length > 0 ? args[0].ToString() : null, cancellationToken),
             "more" or "less" => PagerStreamAsync(stream, cancellationToken),

--- a/Jitzu.Shell/Core/StreamingPipeline.cs
+++ b/Jitzu.Shell/Core/StreamingPipeline.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -321,8 +322,31 @@ public static class StreamingPipeFunctions
         bool linesOnly = false,
         bool wordsOnly = false,
         bool charsOnly = false,
+        bool files = false,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        if (files)
+        {
+            if (wordsOnly || charsOnly)
+                throw new ArgumentException("wc --files supports line counts only");
+
+            await foreach (var line in stream.WithCancellation(cancellationToken))
+            {
+                var path = line.Trim();
+                if (!File.Exists(path))
+                    throw new FileNotFoundException($"wc: file from input stream was not found: {path}", path);
+
+                var fileLineCount = 0L;
+                using var reader = new StreamReader(path);
+                while (await reader.ReadLineAsync(cancellationToken) is not null)
+                    fileLineCount++;
+
+                yield return fileLineCount.ToString(CultureInfo.InvariantCulture);
+            }
+
+            yield break;
+        }
+
         var lineCount = 0;
         var wordCount = 0;
         var charCount = 0;
@@ -351,6 +375,85 @@ public static class StreamingPipeFunctions
             yield return string.Join('\t', parts);
         }
     }
+
+    public static async IAsyncEnumerable<string> SumAsync(
+        IAsyncEnumerable<string> stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var summary = await SummarizeNumbersAsync(stream, cancellationToken);
+        yield return FormatNumber(summary.Sum);
+    }
+
+    public static async IAsyncEnumerable<string> AverageAsync(
+        IAsyncEnumerable<string> stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var summary = await SummarizeNumbersAsync(stream, cancellationToken);
+        if (summary.Count == 0)
+            throw new InvalidOperationException("avg requires at least one number");
+
+        yield return FormatNumber(summary.Sum / summary.Count);
+    }
+
+    public static async IAsyncEnumerable<string> MinAsync(
+        IAsyncEnumerable<string> stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var summary = await SummarizeNumbersAsync(stream, cancellationToken);
+        if (summary.Count == 0)
+            throw new InvalidOperationException("min requires at least one number");
+
+        yield return FormatNumber(summary.Min);
+    }
+
+    public static async IAsyncEnumerable<string> MaxAsync(
+        IAsyncEnumerable<string> stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var summary = await SummarizeNumbersAsync(stream, cancellationToken);
+        if (summary.Count == 0)
+            throw new InvalidOperationException("max requires at least one number");
+
+        yield return FormatNumber(summary.Max);
+    }
+
+    public static async IAsyncEnumerable<string> CountAsync(
+        IAsyncEnumerable<string> stream,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var count = 0L;
+        await foreach (var _ in stream.WithCancellation(cancellationToken))
+            count++;
+
+        yield return count.ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static async Task<NumberSummary> SummarizeNumbersAsync(
+        IAsyncEnumerable<string> stream,
+        CancellationToken cancellationToken)
+    {
+        var count = 0L;
+        var sum = 0d;
+        var min = double.PositiveInfinity;
+        var max = double.NegativeInfinity;
+
+        await foreach (var line in stream.WithCancellation(cancellationToken))
+        {
+            if (!double.TryParse(line.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
+                throw new FormatException($"Expected a number in the pipeline, got '{line}'");
+
+            count++;
+            sum += value;
+            min = Math.Min(min, value);
+            max = Math.Max(max, value);
+        }
+
+        return new NumberSummary(count, sum, min, max);
+    }
+
+    private static string FormatNumber(double value) => value.ToString("G", CultureInfo.InvariantCulture);
+
+    private readonly record struct NumberSummary(long Count, double Sum, double Min, double Max);
 
     /// <summary>
     /// Prints lines to console and passes them through.

--- a/Jitzu.Tests/PipelineAggregationTests.cs
+++ b/Jitzu.Tests/PipelineAggregationTests.cs
@@ -1,0 +1,74 @@
+using Jitzu.Shell.Core;
+using Shouldly;
+
+namespace Jitzu.Tests;
+
+public class PipelineAggregationTests
+{
+    [Test]
+    public async Task NumericAggregators_ReduceTheStream()
+    {
+        (await Materialize(StreamingPipeFunctions.SumAsync(Lines("1", "2", "3", "4"))))
+            .ShouldBe(["10"]);
+        (await Materialize(StreamingPipeFunctions.AverageAsync(Lines("1", "2", "3", "4"))))
+            .ShouldBe(["2.5"]);
+        (await Materialize(StreamingPipeFunctions.MinAsync(Lines("1", "2", "3", "4"))))
+            .ShouldBe(["1"]);
+        (await Materialize(StreamingPipeFunctions.MaxAsync(Lines("1", "2", "3", "4"))))
+            .ShouldBe(["4"]);
+        (await Materialize(StreamingPipeFunctions.CountAsync(Lines("1", "2", "3", "4"))))
+            .ShouldBe(["4"]);
+    }
+
+    [Test]
+    public async Task NumericAggregators_RejectNonNumericInput()
+    {
+        await Should.ThrowAsync<FormatException>(async () =>
+            await Materialize(StreamingPipeFunctions.AverageAsync(Lines("1", "not-a-number"))));
+    }
+
+    [Test]
+    public async Task Average_RejectsAnEmptyStream()
+    {
+        await Should.ThrowAsync<InvalidOperationException>(async () =>
+            await Materialize(StreamingPipeFunctions.AverageAsync(Lines())));
+    }
+
+    [Test]
+    public async Task WcFiles_EmitsOneLineCountPerInputFile()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "jitzu_wc_files_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        var first = Path.Combine(directory, "first.cs");
+        var second = Path.Combine(directory, "second.cs");
+        try
+        {
+            await File.WriteAllTextAsync(first, "one\ntwo\n");
+            await File.WriteAllTextAsync(second, "one\ntwo\nthree\nfour\n");
+
+            var counts = await Materialize(StreamingPipeFunctions.WcAsync(
+                Lines(first, second),
+                linesOnly: true,
+                files: true));
+
+            counts.ShouldBe(["2", "4"]);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static async Task<string[]> Materialize(IAsyncEnumerable<string> stream) =>
+        await StreamingPipeline.MaterializeToArrayAsync(stream);
+
+    private static async IAsyncEnumerable<string> Lines(params string[] lines)
+    {
+        foreach (var line in lines)
+        {
+            yield return line;
+            await Task.Yield();
+        }
+    }
+}

--- a/Jitzu.Tests/StreamingIntegrationTests.cs
+++ b/Jitzu.Tests/StreamingIntegrationTests.cs
@@ -157,6 +157,29 @@ public class StreamingIntegrationTests
     }
 
     [Test]
+    public async Task FindFiles_WcEachFile_Average_ComputesAverageLineCount()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "jitzu_pipeline_avg_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(directory, "two.cs"), "one\ntwo\n");
+            await File.WriteAllTextAsync(Path.Combine(directory, "four.cs"), "one\ntwo\nthree\nfour\n");
+            await File.WriteAllTextAsync(Path.Combine(directory, "ignored.txt"), "one\n");
+
+            var output = await RunCommandAsync(
+                $"find \"{directory}\" -type f -ext .cs | wc -l --files | avg");
+
+            output.ShouldBe("3");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task StreamingPipeline_LargeDataset_HandlesEfficiently()
     {
         // This should complete quickly with streaming

--- a/site/src/content/docs/shell/commands/text-processing.mdx
+++ b/site/src/content/docs/shell/commands/text-processing.mdx
@@ -24,6 +24,8 @@ import CodeBlock from '@/components/CodeBlock.astro';
     <tr><td><code>sort [-r/-n/-u] file</code></td><td>Sort lines</td></tr>
     <tr><td><code>uniq [-c/-d] file</code></td><td>Remove consecutive duplicate lines</td></tr>
     <tr><td><code>wc [-l/-w/-c] file</code></td><td>Count lines, words, or characters</td></tr>
+    <tr><td><code>{'... | wc -l --files'}</code></td><td>Emit a line count for each file path in a stream</td></tr>
+    <tr><td><code>sum / avg / min / max / count</code></td><td>Reduce a numeric stream</td></tr>
     <tr><td><code>diff file1 file2</code></td><td>Compare two files</td></tr>
     <tr><td><code>tr [-d] s1 s2 file</code></td><td>Translate or delete characters</td></tr>
     <tr><td><code>cut -d/-f/-c file</code></td><td>Extract fields or characters</td></tr>

--- a/site/src/content/docs/shell/pipes-and-redirection.mdx
+++ b/site/src/content/docs/shell/pipes-and-redirection.mdx
@@ -58,7 +58,9 @@ c3d4e5f Refactor parser`} />
     <tr><td><code>tail -n N</code></td><td>Last N lines (default 10)</td></tr>
     <tr><td><code>sort [-r]</code></td><td>Sort lines alphabetically</td></tr>
     <tr><td><code>uniq</code></td><td>Remove consecutive duplicate lines</td></tr>
-    <tr><td><code>wc [-l/-w/-c]</code></td><td>Count lines/words/chars</td></tr>
+    <tr><td><code>{'wc [-l/-w/-c] [--files]'}</code></td><td>Count the stream, or emit a count for each input file</td></tr>
+    <tr><td><code>sum / avg / min / max</code></td><td>Aggregate a numeric stream</td></tr>
+    <tr><td><code>count</code></td><td>Count items in a stream</td></tr>
     <tr><td><code>tee [-a] file</code></td><td>Write to file and pass through</td></tr>
     <tr><td><code>more / less</code></td><td>View output in pager</td></tr>
     <tr><td><code>print</code></td><td>Print and pass through</td></tr>
@@ -79,6 +81,12 @@ a1b2c3d Fix login timeout
 c3d4e5f Fix parser edge case
 
 > ls *.cs | sort | tee filelist.txt`} />
+
+Map file paths to line counts with `wc --files`, then reduce the numeric stream. For example,
+this computes the average lines per C# file:
+
+<CodeBlock language="shell" code={`> find . -type f -ext .cs | wc -l --files | avg
+187.4`} />
 
 ## Builtin Pipes
 


### PR DESCRIPTION
## Summary

- add `wc --files` / `wc --each-file` to map a stream of file paths to per-file line counts
- add streaming numeric reducers: `sum`, `avg`, `min`, `max`, and `count`
- parse and format numeric pipeline values with invariant culture
- document and test `find . -type f -ext .cs | wc -l --files | avg`

## Issue analysis

The report's `find -ext` concern was stale because extension filtering already exists. The remaining capability gap was real: there was no way to map a measurement over file paths or reduce numeric output.

## Impact

The shell can now enumerate matching files, measure each file, and aggregate the resulting numeric stream using small composable pipe functions. Invalid numeric input and empty averages/minima/maxima produce explicit errors.

## Validation

- pipeline aggregation unit tests (4 passed)
- end-to-end find → per-file wc → avg integration test (passed)
- `dotnet test --no-restore` (357 passed)
- `npm run build` in `site` (29 pages built)
- verified rendered docs preserve the literal `--files` flag
- `git diff --check`

Closes #30
